### PR TITLE
Added new tests in Account.rs and nep6account.rs

### DIFF
--- a/src/neo_builder/transaction/verification_script.rs
+++ b/src/neo_builder/transaction/verification_script.rs
@@ -192,7 +192,8 @@ impl VerificationScript {
 			Ok(1)
 		} else if self.is_multi_sig() {
 			let reader = &mut Decoder::new(&self.script);
-			Ok(reader.by_ref().read_var_int()? as usize)
+			Ok(reader.by_ref().read_push_int()?.to_usize().unwrap())
+			//Ok(reader.by_ref().read_bigint()?.to_usize().unwrap())
 		} else {
 			Err(BuilderError::InvalidScript("Invalid verification script".to_string()))
 		}

--- a/src/neo_wallets/wallet/nep6account.rs
+++ b/src/neo_wallets/wallet/nep6account.rs
@@ -261,5 +261,41 @@ mod tests {
 			account.address_or_scripthash().address(),
 			TestConstants::DEFAULT_ACCOUNT_ADDRESS
 		);
+		assert_eq!(
+			account.encrypted_private_key().clone().unwrap(),
+			TestConstants::DEFAULT_ACCOUNT_ENCRYPTED_PRIVATE_KEY
+		);
+
+		assert_eq!(
+			account.verification_script.unwrap().script(),
+			&hex::decode(TestConstants::DEFAULT_ACCOUNT_VERIFICATION_SCRIPT).unwrap()
+		);
+	}
+
+	#[test]
+	fn test_load_multi_sig_account_from_nep6() {
+		let data = include_str!("../../../test_resources/wallet/multiSigAccount.json");
+		let nep6_account: NEP6Account = serde_json::from_str(data).unwrap();
+
+		let account = nep6_account.to_account().unwrap();
+
+		assert!(!account.is_default);
+		assert!(!account.is_locked);
+		assert_eq!(
+			account.address_or_scripthash().address(),
+			TestConstants::COMMITTEE_ACCOUNT_ADDRESS
+		);
+		assert_eq!(
+			account.verification_script().clone().unwrap().script(),
+			&hex::decode(TestConstants::COMMITTEE_ACCOUNT_VERIFICATION_SCRIPT).unwrap()
+		);
+		assert_eq!(
+			account.get_nr_of_participants().unwrap(),
+			1
+		);
+		assert_eq!(
+			account.get_signing_threshold().unwrap(),
+			1
+		);
 	}
 }


### PR DESCRIPTION
Account.rs: test_create_multi_sig_account_account_with_address(); test_create_multi_sig_account_account_from_verification_script(); test_fail_encrypt_account_without_private_key().

nep6account.rs: test_load_multi_sig_account_from_nep6().

Fixed some code in account.rs and verification_script.rs to pass the new  added tests