### PR TITLE
Release NeoRust 2.1.0

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,23 +1,8 @@
 # Cargo audit configuration
 
 [advisories]
-# The gtk-rs GTK3 bindings are marked as unmaintained but are still used by Tauri
-# These are not security vulnerabilities, just maintenance status warnings
-# Tauri is working on GTK4 support but GTK3 is still needed for compatibility
 ignore = [
-    "RUSTSEC-2024-0411", # gdkwayland-sys - gtk-rs GTK3 bindings unmaintained
-    "RUSTSEC-2024-0412", # gdk - gtk-rs GTK3 bindings unmaintained
-    "RUSTSEC-2024-0413", # atk - gtk-rs GTK3 bindings unmaintained
-    "RUSTSEC-2024-0414", # gdkx11-sys - gtk-rs GTK3 bindings unmaintained
-    "RUSTSEC-2024-0415", # gtk - gtk-rs GTK3 bindings unmaintained
-    "RUSTSEC-2024-0416", # atk-sys - gtk-rs GTK3 bindings unmaintained
-    "RUSTSEC-2024-0417", # gdkx11 - gtk-rs GTK3 bindings unmaintained
-    "RUSTSEC-2024-0418", # gdk-sys - gtk-rs GTK3 bindings unmaintained
-    "RUSTSEC-2024-0419", # gtk3-macros - gtk-rs GTK3 bindings unmaintained
-    "RUSTSEC-2024-0420", # gtk-sys - gtk-rs GTK3 bindings unmaintained
-    "RUSTSEC-2024-0429", # glib - Known issue, waiting for Tauri update
-    "RUSTSEC-2024-0370", # proc-macro-error - Used by gtk3-macros
-    "RUSTSEC-2024-0384", # instant - Used by fastrand in test dependencies
-    "RUSTSEC-2023-0071", # rsa - Marvin Attack; no upstream fix, transitive via jsonwebtoken
-    "RUSTSEC-2025-0009", # ring - AES panic on overflow checks, unfixable transitive dependency via ethers-rs
+    # jsonwebtoken's RustCrypto provider enables rsa 0.9, but the SDK's JWT implementation only
+    # exposes HS256. No patched rsa 0.9 release is currently available.
+    "RUSTSEC-2023-0071",
 ]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,3 @@
-[package]
-# Prevent accidental publishing to crates.io
-publish = false
-
 [registry]
 default = "crates-io"
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,6 +14,17 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
+  msrv:
+    name: Minimum Supported Rust
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Rust 1.91
+      uses: dtolnay/rust-toolchain@1.91
+    - name: Check library with MSRV
+      run: cargo check -p neo3 --lib --locked --all-features
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -54,7 +54,7 @@ jobs:
     name: Build & Test - ${{ matrix.os }}
     needs: lint
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
     name: Build - ${{ matrix.os }}
     needs: prepare
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,13 @@ on:
 # Cancel in-progress runs when a new run is triggered
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
 
 jobs:
   # Validate and prepare release
@@ -39,17 +42,85 @@ jobs:
           else
             VERSION="${GITHUB_REF#refs/tags/}"
           fi
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Error: release version must be valid v-prefixed SemVer"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Version: ${VERSION}"
 
       - name: Verify Cargo.toml version
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          VERSION_NUM="${VERSION#v}"
           CARGO_VERSION="v$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)"
           if [ "$VERSION" != "$CARGO_VERSION" ]; then
             echo "Error: Tag version ($VERSION) doesn't match Cargo.toml version ($CARGO_VERSION)"
             exit 1
           fi
+
+          CLI_VERSION="$(grep '^version' neo-cli/Cargo.toml | head -1 | cut -d'"' -f2)"
+          if [ "$VERSION_NUM" != "$CLI_VERSION" ]; then
+            echo "Error: neo-cli version ($CLI_VERSION) doesn't match release version ($VERSION_NUM)"
+            exit 1
+          fi
+
+          EXPECTED_CLI_DEPENDENCY="neo3 = { path = \"..\", version = \"${VERSION_NUM}\""
+          if ! grep -Fq "$EXPECTED_CLI_DEPENDENCY" neo-cli/Cargo.toml; then
+            echo "Error: neo-cli must require neo3 ${VERSION_NUM}"
+            exit 1
+          fi
+
+          LOCK_NEO3_VERSION="$(awk '/^name = "neo3"$/ { getline; gsub(/"/, "", $3); print $3; exit }' Cargo.lock)"
+          LOCK_CLI_VERSION="$(awk '/^name = "neo-cli"$/ { getline; gsub(/"/, "", $3); print $3; exit }' Cargo.lock)"
+          if [ "$LOCK_NEO3_VERSION" != "$VERSION_NUM" ] || [ "$LOCK_CLI_VERSION" != "$VERSION_NUM" ]; then
+            echo "Error: Cargo.lock package versions ($LOCK_NEO3_VERSION, $LOCK_CLI_VERSION) don't match $VERSION_NUM"
+            exit 1
+          fi
+
+          if ! grep -q "^## \[${VERSION_NUM}\] - " CHANGELOG.md; then
+            echo "Error: CHANGELOG.md has no dated ${VERSION_NUM} release section"
+            exit 1
+          fi
+
+      - name: Verify locked workspace metadata
+        run: cargo metadata --locked --no-deps --format-version 1 > /dev/null
+
+  verify:
+    name: Verify Release Candidate
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust 1.91
+        uses: dtolnay/rust-toolchain@1.91
+        with:
+          components: rustfmt, clippy
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run Clippy
+        run: cargo clippy --workspace --locked --all-features --all-targets -- -D warnings
+
+      - name: Run workspace tests
+        run: cargo test --workspace --locked
+
+      - name: Build API documentation
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc -p neo3 --locked --all-features --no-deps
+
+      - name: Audit dependencies
+        uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check supply-chain policy
+        uses: EmbarkStudios/cargo-deny-action@v2
 
   # Build release artifacts
   build:
@@ -81,8 +152,8 @@ jobs:
 
       - name: Build release binary
         run: |
-          cargo build --release --target ${{ matrix.target }} --no-default-features --workspace
-          cargo build --release --target ${{ matrix.target }} -p neo-cli --bin neo-cli
+          cargo build --release --locked --target ${{ matrix.target }} --no-default-features --workspace
+          cargo build --release --locked --target ${{ matrix.target }} -p neo-cli --bin neo-cli
 
       - name: Package artifacts (Unix)
         if: runner.os != 'Windows'
@@ -119,6 +190,8 @@ jobs:
     needs: [prepare, build, publish]
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -163,7 +236,7 @@ jobs:
   # Publish crate
   publish:
     name: Publish neo3 crate
-    needs: [prepare, build]
+    needs: [prepare, build, verify]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -195,16 +268,17 @@ jobs:
 
       - name: Verify package
         if: steps.crates.outputs.published != 'true'
-        run: cargo publish --dry-run --locked
+        run: cargo publish --dry-run --locked -p neo3
 
       - name: Publish to crates.io
         if: steps.crates.outputs.published != 'true' && env.CARGO_TOKEN != ''
-        run: cargo publish --locked --token "$CARGO_TOKEN"
+        run: cargo publish --locked -p neo3
 
-      - name: Skip publish without token
+      - name: Require crates.io token
         if: steps.crates.outputs.published != 'true' && env.CARGO_TOKEN == ''
         run: |
-          echo "CARGO_TOKEN is not configured; skipping crates.io publish."
+          echo "CARGO_TOKEN or CRATES_IO_TOKEN must be configured to publish this release."
+          exit 1
 
       - name: Skip already published crate
         if: steps.crates.outputs.published == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,10 +240,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      # The repo historically used `CRATES_IO_TOKEN`; we keep `CARGO_TOKEN`
-      # as the canonical name (matches `docs/RELEASE_PROCESS.md`) and fall
-      # back to the legacy secret so a single token works either way.
-      CARGO_TOKEN: ${{ secrets.CARGO_TOKEN || secrets.CRATES_IO_TOKEN }}
+      # Accept both repository secret names, but expose the token through the
+      # environment variable Cargo uses for crates.io authentication.
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN || secrets.CRATES_IO_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -271,11 +270,11 @@ jobs:
         run: cargo publish --dry-run --locked -p neo3
 
       - name: Publish to crates.io
-        if: steps.crates.outputs.published != 'true' && env.CARGO_TOKEN != ''
+        if: steps.crates.outputs.published != 'true' && env.CARGO_REGISTRY_TOKEN != ''
         run: cargo publish --locked -p neo3
 
       - name: Require crates.io token
-        if: steps.crates.outputs.published != 'true' && env.CARGO_TOKEN == ''
+        if: steps.crates.outputs.published != 'true' && env.CARGO_REGISTRY_TOKEN == ''
         run: |
           echo "CARGO_TOKEN or CRATES_IO_TOKEN must be configured to publish this release."
           exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,99 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No changes yet._
 
+## [2.1.0] - 2026-07-11
+
+NeoRust 2.1.0 makes production failures explicit and recoverable while keeping
+the existing 2.x entry points available. Provider errors now retain useful
+retry metadata, malformed numeric data is rejected instead of silently wrapped,
+and release automation fails closed before publishing incomplete releases.
+
+### Added
+
+- **Checked amount construction:** `DecimalAmount::try_from_raw` validates raw
+  base-unit values from RPC responses, caches, configuration, and user input.
+  Deserialization now uses the same validation path, preventing malformed
+  amounts from entering application state.
+- **Provider-aware unified errors:** `NeoError::provider` preserves rate-limit,
+  retry, validation, wallet, configuration, and network classifications.
+  `CodecError` also converts directly into the unified SDK boundary.
+- **Structured retry classification:** JSON-RPC and provider errors expose
+  retryability, rate limits, server backoff hints, unknown transactions,
+  already-known transactions, and deterministic transaction rejection helpers.
+- **Full-width Neo X transactions:** callers can build and submit Alloy
+  `TransactionRequest` values without the legacy transaction wrapper's `u64`
+  value limit. Existing `NeoXTransaction` serialization and send methods remain
+  available.
+
+### Changed
+
+- **Retries follow provider intent:** deterministic failures return immediately;
+  transient failures use capped exponential backoff, honor bounded
+  `Retry-After` guidance, and release queue capacity correctly after completion
+  or cancellation.
+- **Transaction rebroadcasts are outcome-aware:** an already-known transaction
+  is treated as accepted, deterministic node rejections become transaction
+  errors with the transaction hash, and only transient provider failures are
+  retried.
+- **HTTP failures retain protocol context:** non-success HTTP statuses and
+  JSON-RPC error envelopes keep safe request IDs and retry metadata instead of
+  collapsing into generic transport strings.
+- **Neo X remains source-compatible:** the Alloy-backed provider, wallet,
+  bridge, and transaction paths preserve legacy accessors while adding checked
+  conversions and full-width request APIs.
+- **Release publication is fail-closed:** tagged releases validate package and
+  changelog versions, run formatting, Clippy, tests, rustdoc, audit, and
+  supply-chain policy checks, and require crates.io credentials before creating
+  the GitHub release.
+
+### Fixed
+
+- Contract, policy, bridge, transaction, and string conversions now reject
+  negative or oversized values instead of wrapping through unchecked integer
+  casts. Iterator batch sizes are validated before RPC calls.
+- High-level balance and CLI rendering paths reject malformed decimal counts
+  and amounts, while token filters continue to ignore unrelated malformed
+  entries.
+- Confirmation polling stops on deterministic provider errors rather than
+  converting every failure into a timeout.
+- Name service, notary, token, and smart-contract helpers now propagate
+  provider and script-building failures through their declared error types.
+- Retry classification no longer lowercases and duplicates complete
+  provider-controlled error messages.
+
+### Security
+
+- Provider URLs redact usernames, passwords, query strings, and fragments from
+  `Display` and `Debug`; JSON-RPC error data and HTTP response bodies are not
+  exposed through general-purpose formatting.
+- Dependency policy rejects yanked packages and narrows advisory exceptions.
+  `RUSTSEC-2023-0071` remains explicitly documented because `jsonwebtoken`
+  enables RSA transitively while NeoRust's JWT API exposes HS256 only.
+- The website lockfile updates `http-proxy-middleware` and `js-yaml` past their
+  moderate-severity advisories; `npm audit` reports no remaining findings.
+- Example and CLI manifests are explicitly non-publishable; only the `neo3`
+  package can be released to crates.io.
+
+### Compatibility
+
+- The minimum supported Rust version is now **1.91** (previously 1.83). This is
+  enforced in CI and applies to both `neo3` and the bundled CLI.
+- `DecimalAmount::from_raw` is deprecated in favor of the checked constructor;
+  its zero fallback remains for 2.x source and behavior compatibility.
+- Error `Display`/`Debug` output intentionally omits sensitive provider data.
+  Applications should use structured fields and error helpers instead of
+  parsing formatted error strings.
+
+### Verified
+
+- Strict all-feature and no-default-feature Clippy, the Rust 1.91 all-feature
+  check, the locked workspace test suite, and warnings-as-errors rustdoc pass.
+- `cargo audit` and `cargo deny` pass with the documented RSA exception and
+  unmaintained transitive warnings; `npm audit` reports zero vulnerabilities.
+- The production documentation site builds successfully, GitHub workflows pass
+  `actionlint`, and the `neo3 2.1.0` crates.io dry run verifies a 279-file
+  package including its declared tests and benchmarks.
+
 ## [2.0.1] - 2026-06-18
 
 Security patch release. No public API changes — only dependency hardening.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ and release automation fails closed before publishing incomplete releases.
 - Dependency policy rejects yanked packages and narrows advisory exceptions.
   `RUSTSEC-2023-0071` remains explicitly documented because `jsonwebtoken`
   enables RSA transitively while NeoRust's JWT API exposes HS256 only.
+- The lockfile updates `openssl` and `cmov` past all currently published GitHub
+  security advisories, including the high-severity OpenSSL advisories reported
+  against 0.10.75.
 - The website lockfile updates `http-proxy-middleware` and `js-yaml` past their
   moderate-severity advisories; `npm audit` reports no remaining findings.
 - Example and CLI manifests are explicitly non-publishable; only the `neo3`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ark-ff"
@@ -1141,16 +1141,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bitcoin-consensus-encoding"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+dependencies = [
+ "bitcoin-internals 0.5.0",
+]
+
+[[package]]
 name = "bitcoin-internals"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 
 [[package]]
-name = "bitcoin-io"
-version = "0.1.100"
+name = "bitcoin-internals"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11301df0b06f22dea7bb1916403fdd88a371031e495c49b8f96931b28189e175"
+checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
+dependencies = [
+ "hex-conservative 0.3.2",
+]
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
+dependencies = [
+ "bitcoin-consensus-encoding",
+]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -1158,15 +1179,15 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
 dependencies = [
- "bitcoin-internals",
+ "bitcoin-internals 0.2.0",
  "hex-conservative 0.1.2",
 ]
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.100"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
  "bitcoin-io",
  "hex-conservative 0.2.2",
@@ -1755,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2828,6 +2849,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex-literal"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3618,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "neo-cli"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3656,7 +3686,7 @@ dependencies = [
 
 [[package]]
 name = "neo3"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "aes",
  "alloy",
@@ -4491,9 +4521,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -5130,15 +5160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5190,12 +5211,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
-
-[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5222,7 +5237,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
- "bitcoin_hashes 0.14.100",
+ "bitcoin_hashes 0.14.101",
  "rand 0.8.6",
  "secp256k1-sys 0.10.1",
  "serde",
@@ -5234,7 +5249,7 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
- "bitcoin_hashes 0.14.100",
+ "bitcoin_hashes 0.14.101",
  "rand 0.9.4",
  "secp256k1-sys 0.11.0",
 ]
@@ -5430,24 +5445,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "futures-executor",
  "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,9 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "coins-ledger"
@@ -4013,15 +4013,14 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -4051,9 +4050,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "neo3"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2021"
-rust-version = "1.83"
-authors = ["R3E Network <jimmy@r3e.network> (c) 2020-2025"]
+rust-version = "1.91"
+authors = ["R3E Network <jimmy@r3e.network> (c) 2020-2026"]
 license = "MIT OR Apache-2.0"
+publish = ["crates-io"]
 description = "Production-ready Rust SDK for Neo N3 blockchain with high-level API, unified error handling, and enterprise features"
 documentation = "https://docs.rs/neo3"
-repository = "https://github.com/R3E-Network/NeoRust"
-homepage = "https://github.com/R3E-Network/NeoRust"
+repository = "https://github.com/r3e-network/neo-rust-sdk"
+homepage = "https://github.com/r3e-network/neo-rust-sdk"
 readme = "README.md"
 categories = ["cryptography::cryptocurrencies", "api-bindings", "cryptography"]
 keywords = ["crypto", "neo", "neo-N3", "web3", "blockchain"]
@@ -23,7 +24,9 @@ include = [
     "/LICENSE-MIT",
     "/COPYRIGHT",
     "/assets/**",
+    "/benches/**",
     "/src/**",
+    "/tests/**",
 ]
 
 [lib]
@@ -197,7 +200,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3.23"
 criterion = { version = "0.8", features = ["html_reports"] }
 tempfile = "3.27"
-serial_test = "3.4.0"
+serial_test = "3.5.0"
 proptest = "1.11"
 env_logger = "0.11"
 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@
   <img src="./assets/neo_rust_banner.png" alt="NeoRust SDK Banner" width="100%">
 </p>
 
-[![Build & Test](https://github.com/r3e-network/NeoRust/actions/workflows/build-test.yml/badge.svg)](https://github.com/r3e-network/NeoRust/actions/workflows/build-test.yml)
-[![Release](https://github.com/r3e-network/NeoRust/actions/workflows/release.yml/badge.svg)](https://github.com/r3e-network/NeoRust/actions/workflows/release.yml)
+[![Build & Test](https://github.com/r3e-network/neo-rust-sdk/actions/workflows/build-test.yml/badge.svg)](https://github.com/r3e-network/neo-rust-sdk/actions/workflows/build-test.yml)
+[![Release](https://github.com/r3e-network/neo-rust-sdk/actions/workflows/release.yml/badge.svg)](https://github.com/r3e-network/neo-rust-sdk/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Crates.io](https://img.shields.io/crates/v/neo3.svg)](https://crates.io/crates/neo3)
 [![Documentation](https://docs.rs/neo3/badge.svg)](https://docs.rs/neo3)
-[![MSRV](https://img.shields.io/badge/MSRV-1.83.0-blue)](https://blog.rust-lang.org/2024/11/28/Rust-1.83.0.html)
+[![MSRV](https://img.shields.io/badge/MSRV-1.91.0-blue)](https://blog.rust-lang.org/2025/10/30/Rust-1.91.0.html)
 
 A comprehensive Rust SDK for the Neo N3 blockchain platform. NeoRust provides a production-focused toolkit with simplified APIs, real-time features, and developer tools for building blockchain applications.
 
 ## 📊 Project Status
 
-- **Version**: 2.0.1
-- **Rust Version**: 1.83.0+
+- **Version**: 2.1.0
+- **Rust Version**: 1.91.0+
 - **Neo Version**: Neo N3 compatible
 - **Platform Support**: Linux verified locally; Windows and macOS are intended targets and should be validated in your CI before release
 - **Security**: Dependency auditing via `cargo deny`; wallet exports use authenticated encryption
@@ -35,8 +35,8 @@ A comprehensive Rust SDK for the Neo N3 blockchain platform. NeoRust provides a 
 - 🌐 **Network Support** - Mainnet, Testnet, and custom network configurations
 
 ### Highlights
-- 🌉 **Neo X EVM Integration** - Full `ethers-rs` compatibility with unified cross-chain `EcosystemClient`
-- 🛡️ **Anti-MEV Support** - Built-in secure mempool routing for Neo X to prevent front-running
+- 🌉 **Neo X EVM Integration** - Alloy-backed EVM providers and transactions through the unified cross-chain `EcosystemClient`
+- 🛡️ **Protected RPC Routing** - Optional Neo X routing through a third-party Anti-MEV endpoint; protection depends on the service and is not guaranteed
 - 🌐 **WebSocket Support** - Real-time blockchain events with auto-reconnection
 - 🔑 **HD Wallet (BIP-39/44)** - Hierarchical deterministic wallets with mnemonic phrases
 - 🔮 **Transaction Simulation** - Preview effects and estimate gas before submission
@@ -56,7 +56,7 @@ Add NeoRust to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-neo3 = "2.0.1"
+neo3 = "2.1.0"
 ```
 
 ## Basic Usage
@@ -140,7 +140,7 @@ let client = RpcClient::new(http);
 Requires the `ws` feature:
 
 ```toml
-neo3 = { version = "2.0.1", features = ["ws"] }
+neo3 = { version = "2.1.0", features = ["ws"] }
 ```
 
 ```rust
@@ -214,7 +214,7 @@ if result.success {
 
 ### Neo X & EVM Integration
 
-NeoRust natively supports **Neo X** (the EVM-compatible sidechain) and bridges the gap between NeoVM and EVM environments via `ethers-rs`.
+NeoRust natively supports **Neo X** (the EVM-compatible sidechain) and bridges the gap between NeoVM and EVM environments via Alloy.
 
 ```rust
 use neo3::sdk::unified::EcosystemClient;
@@ -223,10 +223,10 @@ use neo3::neo_x::NeoXWallet;
 // Create a randomized secure EVM wallet
 let wallet = NeoXWallet::create_random();
 
-// Initialize an Anti-MEV protected EcosystemClient for Neo X
+// Route Neo X requests through the configured third-party protected RPC endpoint
 let client = EcosystemClient::new_neox_anti_mev(wallet);
 
-// Query balance using standard ethers-rs providers underneath
+// Query balance using the Alloy-backed provider
 let balance = client.get_balance().await?;
 println!("EVM Balance: {} Wei", balance);
 

--- a/deny.toml
+++ b/deny.toml
@@ -8,18 +8,15 @@ version = 2
 # Note: vulnerability, unsound, and notice are no longer configurable in newer versions
 # They always emit errors and can only be ignored via the ignore field
 unmaintained = "workspace"
-yanked = "warn"
+yanked = "deny"
 
 # Temporarily ignored advisories (no upstream fix available)
 ignore = [
     # RUSTSEC-2023-0071: rsa crate Marvin Attack timing sidechannel.
-    # Transitive dep via jsonwebtoken -> rsa 0.9.x; no patched version exists yet.
+    # jsonwebtoken's RustCrypto provider enables rsa 0.9.x, but the SDK only exposes HS256.
+    # No patched rsa 0.9.x version exists yet.
     # Tracked: https://rustsec.org/advisories/RUSTSEC-2023-0071
     "RUSTSEC-2023-0071",
-    
-    # RUSTSEC-2025-0009: ring crate panic on overflow checks.
-    # Transitive dep via ethers -> jsonwebtoken -> ring; no patched version exists in ethers tree yet.
-    "RUSTSEC-2025-0009",
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -67,13 +64,9 @@ allow = [
     "BSD-3-Clause",
     "CC0-1.0",
     "ISC",
-    "Unicode-DFS-2016",
     "Unicode-3.0",
     "Unlicense",
     "Zlib",
-    "MPL-2.0",
-    # https://github.com/briansmith/ring/issues/902
-    "LicenseRef-ring",
     # https://github.com/briansmith/webpki/issues/148
     "LicenseRef-webpki",
 ]
@@ -81,8 +74,9 @@ allow = [
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-    # root certificate bundle used by rustls/reqwest
+    # root certificate bundles used by rustls/reqwest
     { allow = ["CDLA-Permissive-2.0"], name = "webpki-roots" },
+    { allow = ["CDLA-Permissive-2.0"], name = "webpki-root-certs" },
 ]
 
 [[licenses.clarify]]
@@ -110,8 +104,3 @@ unknown-registry = "deny"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
 unknown-git = "deny"
-
-# List of URLs for allowed Git repositories
-allow-git = [
-    "https://github.com/paritytech/parity-common",
-]

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -516,7 +516,7 @@ let gas = GasEstimator::new(&client)
 ## Support
 
 For issues, questions, or contributions:
-- GitHub: https://github.com/R3E-Network/NeoRust
+- GitHub: https://github.com/r3e-network/neo-rust-sdk
 - Documentation: https://docs.rs/neo3
 - Examples: See `/examples` directory in repository
 

--- a/docs/PRODUCTION_DEPLOYMENT_GUIDE.md
+++ b/docs/PRODUCTION_DEPLOYMENT_GUIDE.md
@@ -75,7 +75,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 cargo build --release -p neo-cli
 
 # Docker deployment
-FROM rust:1.83 as builder
+FROM rust:1.91 AS builder
 WORKDIR /app
 COPY . .
 RUN cargo build --release -p neo-cli

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,8 +9,8 @@
   </p>
 </div>
 
-[![Build & Test](https://github.com/r3e-network/NeoRust/actions/workflows/build-test.yml/badge.svg)](https://github.com/r3e-network/NeoRust/actions/workflows/build-test.yml)
-[![Release](https://github.com/r3e-network/NeoRust/actions/workflows/release.yml/badge.svg)](https://github.com/r3e-network/NeoRust/actions/workflows/release.yml)
+[![Build & Test](https://github.com/r3e-network/neo-rust-sdk/actions/workflows/build-test.yml/badge.svg)](https://github.com/r3e-network/neo-rust-sdk/actions/workflows/build-test.yml)
+[![Release](https://github.com/r3e-network/neo-rust-sdk/actions/workflows/release.yml/badge.svg)](https://github.com/r3e-network/neo-rust-sdk/actions/workflows/release.yml)
 [![Crates.io](https://img.shields.io/crates/v/neo3.svg)](https://crates.io/crates/neo3)
 [![Documentation](https://docs.rs/neo3/badge.svg)](https://docs.rs/neo3)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -58,7 +58,7 @@ cargo build --release
 
 ```toml
 [dependencies]
-neo3 = "2.0.0"
+neo3 = "2.1.0"
 ```
 
 ```rust,no_run
@@ -192,7 +192,7 @@ cargo build --release
 #### For Integration (SDK)
 ```toml
 [dependencies]
-neo3 = "2.0.0"
+neo3 = "2.1.0"
 ```
 
 ### Step 2: Create Your First Wallet
@@ -409,8 +409,8 @@ neo-cli contract invoke --hash "0x..." --method "test" --network testnet
 ## 🌐 Community & Support
 
 ### 📞 Getting Help
-- **GitHub Issues**: [Report bugs and request features](https://github.com/R3E-Network/NeoRust/issues)
-- **Discussions**: [Community discussions and Q&A](https://github.com/R3E-Network/NeoRust/discussions)
+- **GitHub Issues**: [Report bugs and request features](https://github.com/r3e-network/neo-rust-sdk/issues)
+- **Discussions**: [Community discussions and Q&A](https://github.com/r3e-network/neo-rust-sdk/discussions)
 - **Documentation**: [Comprehensive guides and API docs](https://neorust.netlify.app)
 
 ### 🤝 Contributing
@@ -422,7 +422,7 @@ neo-cli contract invoke --hash "0x..." --method "test" --network testnet
 - **Website**: [https://neorust.netlify.app](https://neorust.netlify.app)
 - **Crate**: [https://crates.io/crates/neo3](https://crates.io/crates/neo3)
 - **Documentation**: [https://docs.rs/neo3](https://docs.rs/neo3)
-- **GitHub**: [https://github.com/R3E-Network/NeoRust](https://github.com/R3E-Network/NeoRust)
+- **GitHub**: [https://github.com/r3e-network/neo-rust-sdk](https://github.com/r3e-network/neo-rust-sdk)
 
 ## 📄 License
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -4,37 +4,43 @@ This document describes the release process for NeoRust using GitHub Actions and
 
 ## 🚀 Quick Start for New Releases
 
-### 1. Add Crates.io API Key to GitHub Secrets
+### 1. Add the crates.io API key to GitHub Secrets
 
 **⚠️ SECURITY**: Never commit API keys to the repository!
 
 1. Go to your GitHub repository → **Settings** → **Secrets and variables** → **Actions**
 2. Click **"New repository secret"**
-3. Name: `CARGO_TOKEN`
+3. Name it `CARGO_TOKEN` (preferred) or `CRATES_IO_TOKEN` (legacy fallback)
 4. Value: Your crates.io API token
 5. Click **"Add secret"**
 
 ### 2. Create a New Release
 
 ```bash
-# 1) Update Cargo.toml version + CHANGELOG.md
+# 1) Update Cargo.toml, neo-cli/Cargo.toml, Cargo.lock, and CHANGELOG.md
 # 2) Run local quality checks
-cargo fmt --all
-cargo clippy --workspace --all-features --all-targets
-cargo test --workspace --all-features --all-targets
+cargo fmt --all -- --check
+cargo clippy --workspace --locked --all-features --all-targets -- -D warnings
+cargo test --workspace --locked
+RUSTDOCFLAGS="-D warnings" cargo doc -p neo3 --locked --all-features --no-deps
+cargo audit
+cargo deny check --hide-inclusion-graph
+cargo publish --dry-run --locked
 
 # 3) Tag and push (release workflow triggers on vX.Y.Z tags)
-git tag -a v2.0.0 -m "Release version 2.0.0"
-git push origin v2.0.0
+VERSION=2.1.0
+git tag -a "v${VERSION}" -m "Release neo3 v${VERSION}"
+git push origin "v${VERSION}"
 ```
 
 ### 3. Monitor the Automated Release
 
 The GitHub Actions workflow will automatically:
-- ✅ Validate version format
-- ✅ Run comprehensive quality checks
-- ✅ Create GitHub release
-- ✅ Publish `neo3` to crates.io (best-effort)
+- Validate root/CLI versions, locked metadata, and the dated changelog section
+- Run formatting, Clippy, workspace tests, rustdoc, security audit, and supply-chain policy checks
+- Build Linux, macOS, and Windows CLI artifacts
+- Publish `neo3` to crates.io, failing if credentials are unavailable
+- Create the GitHub release only after publication succeeds
 
 ## 🔄 Automated Workflow Details
 
@@ -97,17 +103,18 @@ Examples: `2.0.0-alpha.1`, `2.0.0-beta.2`, `2.0.0-rc.1`
 
 #### 1. Version Tagging
 ```bash
-# Create and push version tag
-git tag -a v2.0.0 -m "Release version 2.0.0"
-git push origin v2.0.0
+# Set the release version, then create and push the version tag
+VERSION=2.1.0
+git tag -a "v${VERSION}" -m "Release neo3 v${VERSION}"
+git push origin "v${VERSION}"
 ```
 
 #### 2. Automated Release (GitHub Actions)
 The release workflow automatically:
 - [ ] Validates version format and changelog
-- [ ] Runs comprehensive test suite
+- [ ] Runs the release verification suite
 - [ ] Builds binaries for all platforms
-- [ ] Publishes `neo3` to crates.io (best-effort)
+- [ ] Publishes `neo3` to crates.io
 - [ ] Creates GitHub release with artifacts
 - [ ] Extracts release notes from `CHANGELOG.md`
 
@@ -191,8 +198,8 @@ For critical security issues or major bugs:
 6. **Communication**: Immediate security advisory if needed
 
 ### Hotfix Version Numbers
-- Increment PATCH version: `2.0.0` → `1.3.1`
-- For security fixes, consider pre-release: `1.3.1-security.1`
+- Increment PATCH version: `2.1.0` → `2.1.1`
+- For security fixes that require validation before general availability, use a standard pre-release such as `2.1.1-rc.1`
 
 ## 📊 Release Metrics
 
@@ -213,11 +220,13 @@ For critical security issues or major bugs:
 
 ### Local Validation
 ```bash
-# Quick pre-push checks (fmt/clippy + core tests)
-./check-ci.sh
-
-# More thorough checks (includes neo3 doc tests + neo-cli tests)
-./run-ci-checks.sh
+cargo fmt --all -- --check
+cargo clippy --workspace --locked --all-features --all-targets -- -D warnings
+cargo test --workspace --locked
+RUSTDOCFLAGS="-D warnings" cargo doc -p neo3 --locked --all-features --no-deps
+cargo audit
+cargo deny check --hide-inclusion-graph
+cargo publish --dry-run --locked
 ```
 
 ## 🔗 Related Documentation

--- a/docs/SGX_GUIDE.md
+++ b/docs/SGX_GUIDE.md
@@ -29,7 +29,7 @@ NeoRust exposes compile gates and scaffolding for Intel SGX (Software Guard Exte
 - Ubuntu 18.04/20.04/22.04 or Windows 10/11
 - Intel SGX SDK 2.15+
 - Intel SGX PSW (Platform Software)
-- Rust 1.75+ with `no_std` support
+- Rust 1.91+ with `no_std` support
 
 ### Installation
 
@@ -86,7 +86,7 @@ chmod +x sgx_linux_x64_sdk_2.19.100.3.bin
 ```toml
 # Cargo.toml
 [dependencies]
-neo3 = { version = "2.0.0", features = ["sgx", "no_std"] }
+neo3 = { version = "2.1.0", features = ["sgx", "no_std"] }
 
 [target.'cfg(target_env = "sgx")'.dependencies]
 sgx_tstd = { git = "https://github.com/apache/teaclave-sgx-sdk.git", rev = "v2.0.0" }
@@ -416,7 +416,7 @@ let config = EnclaveConfig {
 - [Intel SGX Developer Guide](https://software.intel.com/content/www/us/en/develop/topics/software-guard-extensions.html)
 - [Teaclave SGX SDK](https://github.com/apache/teaclave-sgx-sdk)
 - [SGX Developer Reference](https://download.01.org/intel-sgx/latest/linux-latest/docs/)
-- [NeoRust SGX Examples](https://github.com/R3E-Network/NeoRust/tree/master/examples/sgx_enclave)
+- [NeoRust SGX Examples](https://github.com/r3e-network/neo-rust-sdk/tree/master/examples/sgx_enclave)
 
 ## Summary
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -8,8 +8,8 @@ language = "en"
 [output.html]
 default-theme = "light"
 preferred-dark-theme = "navy"
-git-repository-url = "https://github.com/R3E-Network/NeoRust"
-edit-url-template = "https://github.com/R3E-Network/NeoRust/edit/master/docs/{path}"
+git-repository-url = "https://github.com/r3e-network/neo-rust-sdk"
+edit-url-template = "https://github.com/r3e-network/neo-rust-sdk/edit/master/docs/{path}"
 additional-css = ["theme/custom.css"]
 mathjax-support = true
 copy-fonts = true
@@ -57,4 +57,4 @@ level = 0
 optional = true
 follow-web-links = false
 traverse-parent-directories = false
-exclude = [ "github\\.com", "https://github.com/R3E-Network/NeoRust/blob/master/SGX_SETUP.md" ]
+exclude = [ "github\\.com", "https://github.com/r3e-network/neo-rust-sdk/blob/master/SGX_SETUP.md" ]

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -14,7 +14,7 @@ Add the Neo Rust SDK to your Cargo.toml file:
 
 ```toml
 [dependencies]
-neo3 = "2.0.0"
+neo3 = "2.1.0"
 ```
 
 ## Basic Usage

--- a/docs/guides/choosing-an-api.md
+++ b/docs/guides/choosing-an-api.md
@@ -15,10 +15,10 @@ switch.
 | You want to… | Use | Returns |
 |---|---|---|
 | Connect in one line, query block height / balance | `sdk::Neo` | `Balance`, `u32`, … |
-| Send or transfer NEP-17 tokens with retry + signing handled | `sdk::Neo::transfer` | `TxHash` |
-| Read a contract method without sending a tx | `sdk::Neo::invoke_read` | `InvocationResult` |
-| Write/call a contract method (broadcasts a tx) | `sdk::Neo::invoke_write` | `TxHash` |
-| Deploy a contract | `sdk::Neo::deploy_contract` | `TxHash` |
+| Send or transfer NEP-17 tokens with retry + signing handled | `sdk::Neo::transfer` | `sdk::TxHash` |
+| Read a contract method without sending a tx | `sdk::Neo::invoke_read` | `serde_json::Value` |
+| Write/call a contract method (broadcasts a tx) | `sdk::Neo::invoke_write` | `sdk::TxHash` |
+| Deploy a contract | `sdk::Neo::deploy_contract` | `neo_types::ScriptHash` |
 | Wait for a tx to confirm | `sdk::Neo::wait_for_confirmation` | `()` |
 | HD / BIP-39 wallet generation | `sdk::hd_wallet::HDWallet` | `Account` |
 | Preview a tx's fees/state-changes before sending | `sdk::transaction_simulator` | `SimulationResult` |
@@ -27,6 +27,9 @@ switch.
 | Build a raw script / sign manually / control every byte | `builder::TransactionBuilder` + `builder::ScriptBuilder` | `Transaction` |
 | Work with Neo X (EVM sidechain) | `neo_x::NeoXWallet`, `sdk::unified::EcosystemClient` | EVM types |
 | Store/retrieve on NeoFS | `neo_fs::client` | NeoFS objects |
+
+The high-level `sdk::TxHash` is a hex-encoded `String`. It is distinct from
+`neo_types::TxHash`, the low-level alias for `H256`.
 
 ---
 

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Rust and Cargo (stable or nightly)
+- Rust 1.91 or later with Cargo
 - Optional: Ledger hardware device (for ledger features)
 - Optional: YubiHSM device (for hardware security module features)
 
@@ -12,10 +12,10 @@ Add NeoRust to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-neo3 = "2.0.0"
+neo3 = "2.1.0"
 ```
 
-Note: The crate is published as `neo3` but is imported as `neo` in code:
+The crate is published and imported as `neo3`:
 
 ```rust,no_run
 use neo3::prelude::*;
@@ -38,7 +38,7 @@ Example of enabling specific features:
 
 ```toml
 [dependencies]
-neo3 = { version = "2.0.0", features = ["futures", "ws", "ledger"] }
+neo3 = { version = "2.1.0", features = ["futures", "ws", "ledger"] }
 ```
 
 ### Development vs Production Features
@@ -47,21 +47,21 @@ For development and testing, you can enable mock functionality:
 
 ```toml
 [dependencies]
-neo3 = { version = "2.0.0", features = ["futures", "mock-hsm"] }
+neo3 = { version = "2.1.0", features = ["futures", "mock-hsm"] }
 ```
 
 For production builds, avoid mock features:
 
 ```toml
 [dependencies]
-neo3 = { version = "2.0.0", features = ["futures", "ws", "ipc", "ledger"] }
+neo3 = { version = "2.1.0", features = ["futures", "ws", "ipc", "ledger"] }
 ```
 
 You can disable default features with:
 
 ```toml
 [dependencies]
-neo3 = { version = "2.0.0", default-features = false, features = ["futures"] }
+neo3 = { version = "2.1.0", default-features = false, features = ["futures"] }
 ```
 
 ## Build Configuration

--- a/docs/guides/websocket.md
+++ b/docs/guides/websocket.md
@@ -5,7 +5,7 @@ Real-time blockchain events are available through `neo3::sdk::websocket`. The cl
 Requires the `ws` feature:
 
 ```toml
-neo3 = { version = "2.0.0", features = ["ws"] }
+neo3 = { version = "2.1.0", features = ["ws"] }
 ```
 
 ## Quickstart

--- a/docs/neo-x/README.md
+++ b/docs/neo-x/README.md
@@ -2,13 +2,13 @@
 
 ## Overview
 
-Neo X is an EVM-compatible chain maintained by Neo, enabling developers to leverage Ethereum compatibility while benefiting from Neo's infrastructure and security. The Neo X module in NeoRust provides interfaces for interacting with this EVM-compatible environment directly utilizing `ethers-rs`.
+Neo X is an EVM-compatible chain maintained by Neo, enabling developers to leverage Ethereum compatibility while benefiting from Neo's infrastructure and security. The Neo X module in NeoRust provides interfaces for interacting with this EVM-compatible environment using Alloy.
 
 ## Key Features
 
-- **EVM Compatibility Layer**: Interact with Neo X as an Ethereum-compatible chain via `ethers-rs`
+- **EVM Compatibility Layer**: Interact with Neo X as an Ethereum-compatible chain via Alloy
 - **Unified Ecosystem Client**: Seamlessly write code that operates across Neo N3 and Neo X
-- **Anti-MEV Protection**: Connect directly to obfuscated/protected mempools to prevent front-running
+- **Protected RPC Routing**: Optionally route requests through a third-party Anti-MEV endpoint; the service may mitigate MEV exposure but does not guarantee prevention
 - **Bridge Functionality**: Transfer tokens seamlessly between Neo N3 and Neo X natively
 - **Transaction Support**: Create, sign, and send EVM transactions on Neo X
 
@@ -27,8 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a new randomized EVM Wallet (or load from PK)
     let evm_wallet = NeoXWallet::create_random();
 
-    // Initialize an Anti-MEV protected EcosystemClient for Neo X
-    // This routes your transactions through a protected mempool endpoint
+    // Route requests through the configured third-party protected RPC endpoint
     let client = EcosystemClient::new_neox_anti_mev(evm_wallet);
 
     // Get Balance directly via the Unified Interface
@@ -41,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### Neo X Provider & Wallet
 
-If you need deeper access, you can work directly with the `NeoXProvider` and `NeoXWallet`. The `NeoXProvider` wraps an `ethers::providers::Provider<Http>` for executing low-level EVM requests.
+If you need deeper access, you can work directly with the `NeoXProvider` and `NeoXWallet`. The `NeoXProvider` exposes an Alloy `RootProvider` for executing low-level EVM requests.
 
 ```rust,no_run
 use neo3::neo_clients::{HttpProvider, RpcClient};
@@ -51,9 +50,9 @@ use neo3::neo_x::{NeoXProvider, NeoXWallet, NeoXClient};
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let neo_x_provider: NeoXProvider<'_, HttpProvider> = NeoXProvider::new("https://rpc.neo-x.org", None);
     
-    // Extract the raw ethers provider if you need native EVM interactions
-    let raw_evm = neo_x_provider.evm_provider().unwrap();
-    let chain_id = raw_evm.get_chainid().await.unwrap();
+    // Extract the Alloy provider if you need native EVM interactions
+    let _raw_evm = neo_x_provider.evm_provider().unwrap();
+    let chain_id = neo_x_provider.chain_id().await?;
 
     let wallet = NeoXWallet::create_random();
     let client = NeoXClient::new(wallet, neo_x_provider);
@@ -88,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 Neo X's EVM compatibility enables integration with popular Ethereum development tools:
 
-- **ethers-rs**: NeoRust utilizes `ethers-rs` under the hood for all EVM logic, providing maximum reliability and compatibility.
+- **Alloy**: NeoRust uses Alloy for EVM providers, signing, transaction types, and RPC interoperability.
 - **Metamask**: Connect Metamask to Neo X by adding it as a custom network.
 - **Hardhat/Foundry**: Deploy Solidity contracts to Neo X.
 - **Web3.js/ethers.js**: Interact with Neo X using JavaScript libraries.
@@ -97,7 +96,7 @@ Neo X's EVM compatibility enables integration with popular Ethereum development 
 
 - **Gas Costs**: Neo X uses a gas model similar to Ethereum. Transactions cost native GAS token.
 - **Cross-Chain Operations**: Bridge operations require network confirmations and may take a few minutes to finalize.
-- **Security**: The Anti-MEV endpoint prevents sandwich attacks and front-running on decentralized exchanges deployed on Neo X.
+- **Security**: The optional Anti-MEV mode routes through a third-party protected RPC endpoint. Its effectiveness depends on that service and does not guarantee prevention of front-running or sandwich attacks.
 
 ## Related Documentation
 

--- a/docs/src/guides/getting-started.md
+++ b/docs/src/guides/getting-started.md
@@ -4,7 +4,7 @@ This guide will help you get started with the NeoRust SDK for interacting with t
 
 ## Prerequisites
 
-- Rust 1.83.0 or later
+- Rust 1.91.0 or later
 - Cargo package manager
 - Basic knowledge of the Neo blockchain
 
@@ -14,7 +14,7 @@ Add the NeoRust SDK to your Cargo.toml:
 
 ```toml
 [dependencies]
-neo3 = { git = "https://github.com/R3E-Network/NeoRust" }
+neo3 = { git = "https://github.com/r3e-network/neo-rust-sdk" }
 ```
 
 Or if you prefer to use a specific version:

--- a/docs/src/guides/installation.md
+++ b/docs/src/guides/installation.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Rust and Cargo (stable or nightly)
+- Rust 1.91 or later with Cargo
 - Optional: Ledger hardware device (for ledger features)
 - Optional: YubiHSM device (for hardware security module features)
 
@@ -12,10 +12,10 @@ Add NeoRust to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-neo3 = "2.0.0"
+neo3 = "2.1.0"
 ```
 
-Note: The crate is published as `neo3` but is imported as `neo` in code:
+The crate is published and imported as `neo3`:
 
 ```rust,no_run
 use neo3::prelude::*;
@@ -38,14 +38,14 @@ Example of enabling specific features:
 
 ```toml
 [dependencies]
-neo3 = { version = "2.0.0", features = ["futures", "ws", "ledger"] }
+neo3 = { version = "2.1.0", features = ["futures", "ws", "ledger"] }
 ```
 
 You can disable default features with:
 
 ```toml
 [dependencies]
-neo3 = { version = "2.0.0", default-features = false, features = ["futures"] }
+neo3 = { version = "2.1.0", default-features = false, features = ["futures"] }
 ```
 
 ## Verifying Installation

--- a/docs/src/reference/api-overview.md
+++ b/docs/src/reference/api-overview.md
@@ -217,7 +217,7 @@ Enable these features in your Cargo.toml:
 
 ```toml
 [dependencies]
-neo3 = { version = "2.0.0", features = ["ledger", "ws"] }
+neo3 = { version = "2.1.0", features = ["ledger", "ws"] }
 ```
 
 ## Error Handling

--- a/docs/src/reference/copyright.md
+++ b/docs/src/reference/copyright.md
@@ -8,8 +8,8 @@ NeoRust is Copyright © 2020-2025 R3E Network and contributors.
 
 NeoRust is dual-licensed under:
 
-- MIT License ([LICENSE-MIT](https://github.com/R3E-Network/NeoRust/blob/master/LICENSE-MIT))
-- Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/R3E-Network/NeoRust/blob/master/LICENSE-APACHE))
+- MIT License ([LICENSE-MIT](https://github.com/r3e-network/neo-rust-sdk/blob/master/LICENSE-MIT))
+- Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/r3e-network/neo-rust-sdk/blob/master/LICENSE-APACHE))
 
 ## Copyright Format
 

--- a/docs/superpowers/plans/2026-07-11-neo-rust-sdk-2.1.0-release.md
+++ b/docs/superpowers/plans/2026-07-11-neo-rust-sdk-2.1.0-release.md
@@ -1,0 +1,106 @@
+# NeoRust 2.1.0 Release Plan
+
+> **For maintainers:** Execute each gate in order. Do not create or push the release tag until the release commit is on `master` and every required check passes.
+
+**Goal:** Ship the completed SDK correctness, reliability, security, and developer-experience work as NeoRust `2.1.0`.
+
+**Version rationale:** The change set adds backwards-compatible public SDK capabilities, strengthens provider and retry behavior, and raises the minimum supported Rust version from 1.83 to 1.91. Under the repository's SemVer policy this is a minor release, not a patch; existing 2.x entry points remain available.
+
+**Release architecture:** The repository publishes from an annotated `vX.Y.Z` tag through `.github/workflows/release.yml`. The tag must match the root `neo3` package version. GitHub Actions builds cross-platform CLI artifacts, runs `cargo publish --dry-run --locked`, publishes `neo3` when the repository token is configured, and creates the GitHub release from the matching `CHANGELOG.md` section. `neo-cli` is versioned with the SDK for artifact clarity but is not published to crates.io.
+
+**Constraints:** Preserve the existing hardening diff, add no dependencies, keep 2.x API compatibility, use Rust 1.91 as the MSRV, and never retry a crates.io publication blindly after an ambiguous failure. The known `RUSTSEC-2023-0071` exception remains limited to the transitive RSA feature that the SDK's HS256-only JWT API does not exercise.
+
+---
+
+## Task 1: Establish the release branch and baseline
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-07-11-neo-rust-sdk-2.1.0-release.md`
+- Inspect: `Cargo.toml`
+- Inspect: `neo-cli/Cargo.toml`
+- Inspect: `Cargo.lock`
+- Inspect: `CHANGELOG.md`
+- Inspect: `.github/workflows/release.yml`
+- Inspect: `docs/RELEASE_PROCESS.md`
+
+1. Confirm `v2.1.0` does not exist locally, on GitHub, or on crates.io.
+2. Confirm GitHub authentication, repository permissions, default branch, and the most recent successful release convention.
+3. Create `release/v2.1.0` from the current dirty `master` worktree without resetting or stashing the completed work.
+4. Record the pre-release `master` commit and inspect all changed files before staging anything.
+
+## Task 2: Update release metadata and notes
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `neo-cli/Cargo.toml`
+- Modify: `Cargo.lock`
+- Modify: `CHANGELOG.md`
+- Modify: `.github/workflows/release.yml`
+- Modify: `.cargo/config.toml`
+- Modify: `examples/*/Cargo.toml` where publication is not already disabled
+- Modify as factually required: `README.md`
+- Modify as factually required: `docs/RELEASE_PROCESS.md`
+
+1. Change the root `neo3` version from `2.0.1` to `2.1.0`.
+2. Change `neo-cli` to `2.1.0` and its local `neo3` dependency requirement to `2.1.0`.
+3. Regenerate the lockfile through Cargo and verify both workspace packages resolve to `2.1.0`.
+4. Make publication intent explicit: only `neo3` publishes to crates.io; the CLI and examples remain applications/examples and cannot be published accidentally.
+5. Make the tag workflow run release verification and fail when crates.io credentials are missing rather than producing a partial green release.
+6. Replace the empty Unreleased placeholder with a dated `2.1.0` entry covering public API additions, correctness fixes, retry/provider hardening, secret redaction, contract/CLI fixes, Neo X compatibility, dependency policy, MSRV, and verification.
+7. Restore an empty Unreleased section above the release entry and add/update changelog comparison links if the file uses them.
+8. Audit release-facing documentation for stale version, MSRV, feature, and behavior claims. Make only factual updates supported by the code.
+
+## Task 3: Run local release gates
+
+Run from the repository root and retain terminal results:
+
+1. `cargo fmt --all --check`
+2. `git diff --check`
+3. `cargo clippy --workspace --locked --all-features --all-targets -- -D warnings`
+4. `cargo clippy --workspace --locked --no-default-features --all-targets -- -D warnings`
+5. `cargo +1.91.0 check -p neo3 --lib --locked --all-features`
+6. `cargo test --workspace --locked`
+7. `RUSTDOCFLAGS="-D warnings" cargo doc -p neo3 --locked --all-features --no-deps`
+8. `cargo audit`
+9. `cargo deny check --hide-inclusion-graph`
+10. `cargo publish --dry-run --locked --allow-dirty`
+11. Inspect the generated package list and unpacked manifest to confirm required documentation, licenses, sources, and lockfile are present and no local-only paths leak into the published package.
+
+If a gate fails, fix the underlying release or implementation issue and rerun that gate plus any downstream gate affected by the change.
+
+## Task 4: Review and commit the release candidate
+
+**Files:** all intentional implementation, test, policy, and release files in the branch.
+
+1. Obtain an independent API/security/release review of the complete diff against `v2.0.1`.
+2. Resolve every correctness, security, publication, and compatibility finding; document accepted low-risk limitations in release notes where user-visible.
+3. Stage only the reviewed files by explicit path.
+4. Create logical Lore-formatted commits with intent-first subjects and `Confidence`, `Scope-risk`, `Tested`, and `Not-tested` trailers.
+5. Confirm the release branch is clean and the final commit still reports package version `2.1.0`.
+
+## Task 5: Validate the release branch remotely
+
+1. Push `release/v2.1.0` to `origin`.
+2. Open a pull request to `master` with the release notes, risk disclosures, and exact local verification evidence.
+3. Wait for all required GitHub checks and review the logs for skipped or best-effort failures, not only the aggregate status.
+4. Merge only after the head SHA and passing checks match the reviewed release candidate.
+5. Fetch `origin/master` and verify the merged release commit, version metadata, and changelog content.
+
+## Task 6: Publish and verify `v2.1.0`
+
+1. Create an annotated `v2.1.0` tag on the verified release commit and push only that tag.
+2. Monitor the GitHub `Release` workflow through completion, including prepare, platform builds, crates.io publish, and GitHub release jobs.
+3. If publication status is ambiguous, query crates.io before retrying. Crate versions are immutable.
+4. Verify all of the following independently:
+   - `v2.1.0` resolves to the intended commit locally and on GitHub.
+   - The GitHub release is public, non-draft, and contains Linux, macOS, and Windows artifacts.
+   - crates.io reports `neo3 = 2.1.0` and the downloadable package matches the reviewed metadata.
+   - docs.rs has queued or completed documentation for `neo3 2.1.0`.
+   - GitHub Actions has no failed or cancelled release job.
+5. Report the release URLs, commit/tag SHA, verification evidence, changed files, simplifications delivered, and remaining risks.
+
+## Rollback Boundaries
+
+- Before the tag is pushed: amend the release branch and rerun affected gates.
+- After the tag is pushed but before crates.io publication: fix forward with a new commit and replacement tag only if GitHub shows the tag has not triggered externally; otherwise use a new patch version.
+- After crates.io publication: never delete or overwrite `2.1.0`; publish a corrective `2.1.1`.

--- a/examples/advanced/Cargo.toml
+++ b/examples/advanced/Cargo.toml
@@ -2,6 +2,7 @@
 name = "advanced-examples"
 version = "0.1.0"
 edition = "2021"
+publish = false
 description = "Advanced Neo N3 examples for enterprise applications"
 
 [[example]]

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -2,6 +2,7 @@
 name = "basic-examples"
 version = "0.1.0"
 edition = "2021"
+publish = false
 description = "Basic Neo N3 examples for beginners"
 
 [dependencies]

--- a/examples/contract_interaction/Cargo.toml
+++ b/examples/contract_interaction/Cargo.toml
@@ -2,6 +2,7 @@
 name = "contract_interaction_example"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 tokio = { version = "1.50", features = ["full"] }

--- a/examples/contracts/README.md
+++ b/examples/contracts/README.md
@@ -1,56 +1,22 @@
-# Contracts
+# Contract Examples
 
-In this guide, we will go over some examples of using ethers-rs to work with contracts, including using abigen to
-generate Rust bindings for a contract, listening for contract events, calling contract methods, and instantiating
-contracts.
+These examples demonstrate Neo N3 contract manifests, script construction, method invocation,
+events, deployment concepts, and the SDK's typed native and token contract wrappers.
 
-## Generating Rust bindings with abigen
+Neo N3 contracts use a manifest ABI and NeoVM parameters rather than an Ethereum Solidity ABI.
+Start with these SDK surfaces:
 
-To use a contract with ethers-rs, you will need to generate Rust bindings using the abigen tool. abigen is included with
-the ethers-rs library and can be used to generate Rust bindings for any Solidity contract.
+- `SmartContractTrait` for low-level read and invoke helpers.
+- `FungibleTokenContract` and `NonFungibleTokenContract` for NEP-17 and NEP-11 contracts.
+- `ContractParameter` and `ScriptBuilder` for explicit NeoVM calls.
+- `ContractManagement` for native deployment and update operations.
 
-### Generate a Rust file
+Run an example from the workspace root:
 
-This method takes a smart contract's Application Binary Interface (ABI) file and generates a Rust file to interact with
-it. This is useful if the smart contract is referenced in different places in a project. File generation from ABI can
-also be easily included as a build step of your application.
-
-Running the code below will generate a file called `token.rs` containing the bindings inside, which exports an
-`ERC20Token` struct, along with all its events and methods. Put into a `build.rs` file this will generate the bindings
-during cargo build.
-
-```rust
-Abigen::new("ERC20Token", "./abi.json")?.generate()?.write_to_file("token.rs")?;
+```bash
+cargo run -p examples-contracts --example neo_contract_interaction
+cargo run -p examples-contracts --example methods
 ```
 
-### Generate inline Rust bindings
-
-This method takes a smart contract's solidity definition and generates inline Rust code to interact with it. This is
-useful for fast prototyping and for tight scoped use-cases of your contracts. Inline Rust generation uses the `abigen!`
-macro to expand Rust contract bindings.
-
-Running the code below will generate bindings for the `ERC20Token` struct, along with all its events and methods.
-
-```rust
-abigen!(
-    ERC20Token,
-    r#"[
-        function approve(address spender, uint256 amount) external returns (bool)
-        event Transfer(address indexed from, address indexed to, uint256 value)
-        event Approval(address indexed owner, address indexed spender, uint256 value)
-    ]"#,
-);
-```
-
-Another way to get the same result, is to provide the ABI contract's definition as follows.
-
-```rust 
-abigen!(ERC20Token, "./abi.json",);
-```
-
-## Contract instances
-
-## Contract methods
-
-## Contract events
-
+For Neo X EVM contracts, use the Alloy-backed APIs in `neo3::neo_x`; the bridge binding in
+`src/neo_x/bridge/evm_bridge.rs` is a compact `alloy::sol!` example.

--- a/examples/intermediate/Cargo.toml
+++ b/examples/intermediate/Cargo.toml
@@ -2,6 +2,7 @@
 name = "intermediate-examples"
 version = "0.1.0"
 edition = "2021"
+publish = false
 description = "Intermediate Neo N3 examples for application developers"
 
 [[example]]

--- a/examples/message_signing/Cargo.toml
+++ b/examples/message_signing/Cargo.toml
@@ -2,6 +2,7 @@
 name = "message_signing_example"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 neo3 = { path = "../.." }

--- a/examples/neo_crypto/Cargo.toml
+++ b/examples/neo_crypto/Cargo.toml
@@ -2,6 +2,7 @@
 name = "neo_crypto"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 neo3 = { path = "../.." }

--- a/examples/neo_famous_contracts/Cargo.toml
+++ b/examples/neo_famous_contracts/Cargo.toml
@@ -2,6 +2,7 @@
 name = "neo_famous_contracts"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 
 [features]

--- a/examples/sgx_enclave/Cargo.toml
+++ b/examples/sgx_enclave/Cargo.toml
@@ -2,6 +2,7 @@
 name = "neo-sgx-example"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 neo3 = { path = "../..", features = ["sgx", "no_std"] }

--- a/neo-cli/Cargo.toml
+++ b/neo-cli/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "neo-cli"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2021"
+rust-version = "1.91"
+publish = false
 description = "Command-line interface for the NeoRust SDK"
-authors = ["R3E Network (c) 2020-2025"]
+authors = ["R3E Network (c) 2020-2026"]
 license = "MIT"
 documentation = "https://docs.rs/neo-cli"
-repository = "https://github.com/R3E-Network/NeoRust"
-homepage = "https://github.com/R3E-Network/NeoRust"
+repository = "https://github.com/r3e-network/neo-rust-sdk"
+homepage = "https://github.com/r3e-network/neo-rust-sdk"
 readme = "README.md"
 
 [[bin]]
@@ -23,7 +25,7 @@ files = []
 neofs = []
 
 [dependencies]
-neo3 = { path = "..", version = "2.0.1", features = ["futures", "ledger", "ws"] }
+neo3 = { path = "..", version = "2.1.0", features = ["futures", "ledger", "ws"] }
 tokio = { version = "1.50", features = ["full"] }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/neo-cli/src/commands/defi/utils.rs
+++ b/neo-cli/src/commands/defi/utils.rs
@@ -259,7 +259,9 @@ pub fn format_token_amount(raw_amount: i64, decimals: u8) -> String {
 		("", raw_amount.to_string())
 	};
 
-	let formatted = DecimalAmount::from_raw(raw, decimals).to_fixed_string();
+	let formatted = DecimalAmount::try_from_raw(raw, decimals)
+		.expect("the absolute value of an i64 is a valid raw amount")
+		.to_fixed_string();
 	format!("{}{}", sign, formatted)
 }
 

--- a/neo-cli/src/commands/wallet.rs
+++ b/neo-cli/src/commands/wallet.rs
@@ -1306,11 +1306,6 @@ async fn handle_balance(
 		let mut rows = 0usize;
 		for bal in balances.balances {
 			let symbol = bal.symbol.clone().unwrap_or_else(|| "<unknown>".to_string());
-			let decimals_str = bal.decimals.clone().unwrap_or_else(|| "0".to_string());
-			let decimals = decimals_str.parse::<u8>().unwrap_or(0);
-			let amount =
-				neo3::sdk::DecimalAmount::from_raw(bal.amount.clone(), decimals).to_fixed_string();
-
 			if let Some(filter_upper) = token_filter_upper.as_deref() {
 				let asset_hex = format!("{:x}", bal.asset_hash);
 				let filter_hex = token_filter_hex.as_deref().unwrap_or("");
@@ -1320,6 +1315,22 @@ async fn handle_balance(
 					continue;
 				}
 			}
+
+			let decimals_str = bal.decimals.clone().unwrap_or_else(|| "0".to_string());
+			let decimals = decimals_str.parse::<u8>().map_err(|err| {
+				CliError::Rpc(format!(
+					"Invalid decimals '{}' for token {}: {}",
+					decimals_str, bal.asset_hash, err
+				))
+			})?;
+			let amount = neo3::sdk::DecimalAmount::try_from_raw(bal.amount.clone(), decimals)
+				.map_err(|err| {
+					CliError::Rpc(format!(
+						"Invalid balance '{}' for token {}: {}",
+						bal.amount, bal.asset_hash, err
+					))
+				})?
+				.to_fixed_string();
 
 			rows += 1;
 			if detailed {
@@ -1671,4 +1682,69 @@ async fn handle_transaction_simulation(
 	}
 
 	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use tokio::{
+		io::{AsyncReadExt, AsyncWriteExt},
+		net::TcpListener,
+	};
+
+	async fn state_returning_balances(body: String) -> (CliState, tokio::task::JoinHandle<()>) {
+		let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+		let endpoint = format!("http://{}", listener.local_addr().unwrap());
+		let server = tokio::spawn(async move {
+			let (mut stream, _) = listener.accept().await.unwrap();
+			let mut request = vec![0_u8; 4096];
+			let _ = stream.read(&mut request).await.unwrap();
+
+			let response = format!(
+				"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+				body.len(),
+				body
+			);
+			stream.write_all(response.as_bytes()).await.unwrap();
+		});
+		let provider = HttpProvider::new(endpoint.as_str()).unwrap();
+		let state = CliState { rpc_client: Some(RpcClient::new(provider)), ..CliState::default() };
+		(state, server)
+	}
+
+	#[tokio::test]
+	async fn balance_filter_ignores_malformed_unrelated_token() {
+		let body = r#"{"jsonrpc":"2.0","id":0,"result":{"address":"NUrPrFLETzoe7N2FLi2dqTvLwc9L2Em84K","balance":[{"assethash":"0xd2a4cff31913016155e38e474a2c06d08be276cf","symbol":"BAD","decimals":"not-a-number","amount":"also-invalid","lastupdatedblock":1},{"assethash":"0xef4073a0f2b305a38ec4050e4d3d28bc40ea63f5","symbol":"GAS","decimals":"8","amount":"100000000","lastupdatedblock":2}]}}"#;
+		let (state, server) = state_returning_balances(body.to_string()).await;
+		let result = handle_balance(
+			Some("NUrPrFLETzoe7N2FLi2dqTvLwc9L2Em84K".to_string()),
+			Some("GAS".to_string()),
+			false,
+			&state,
+		)
+		.await;
+		server.await.unwrap();
+
+		assert!(
+			result.is_ok(),
+			"filtered balance should ignore malformed unrelated tokens: {result:?}"
+		);
+	}
+
+	#[tokio::test]
+	async fn selected_malformed_balance_is_an_rpc_error() {
+		let body = r#"{"jsonrpc":"2.0","id":0,"result":{"address":"NUrPrFLETzoe7N2FLi2dqTvLwc9L2Em84K","balance":[{"assethash":"0xd2a4cff31913016155e38e474a2c06d08be276cf","symbol":"BAD","decimals":"not-a-number","amount":"also-invalid","lastupdatedblock":1}]}}"#;
+		let (state, server) = state_returning_balances(body.to_string()).await;
+
+		let result = handle_balance(
+			Some("NUrPrFLETzoe7N2FLi2dqTvLwc9L2Em84K".to_string()),
+			Some("BAD".to_string()),
+			false,
+			&state,
+		)
+		.await;
+		server.await.unwrap();
+
+		assert!(matches!(result, Err(CliError::Rpc(_))));
+	}
 }

--- a/src/neo_builder/transaction/transaction.rs
+++ b/src/neo_builder/transaction/transaction.rs
@@ -455,10 +455,7 @@ impl<'a, T: JsonRpcProvider + 'static> Transaction<'a, T> {
 		})?);
 		// self.throw()?;
 		self.block_count_when_sent = Some(network.get_block_count().await?);
-		network
-			.send_raw_transaction(hex)
-			.await
-			.map_err(|e| TransactionError::IllegalState(e.to_string()))
+		network.send_raw_transaction(hex).await.map_err(TransactionError::ProviderError)
 	}
 
 	/// Tracks a transaction until it appears in a block.

--- a/src/neo_clients/errors.rs
+++ b/src/neo_clients/errors.rs
@@ -62,6 +62,76 @@ pub enum ProviderError {
 	NetworkNotFound,
 }
 
+impl ProviderError {
+	/// Returns `true` when repeating the same provider request may succeed.
+	pub fn is_retryable(&self) -> bool {
+		match self {
+			Self::HTTPError(error) => is_retryable_http_error(error),
+			Self::JsonRpcError(error) => error.is_retryable(),
+			_ => false,
+		}
+	}
+
+	/// Returns `true` when this error represents provider throttling.
+	pub fn is_rate_limited(&self) -> bool {
+		match self {
+			Self::HTTPError(error) => {
+				error.status() == Some(reqwest::StatusCode::TOO_MANY_REQUESTS)
+			},
+			Self::JsonRpcError(error) => error.is_rate_limited(),
+			_ => false,
+		}
+	}
+
+	/// Returns a provider-suggested delay before retrying, when present.
+	///
+	/// Untrusted hints are clamped to 60 seconds by the built-in transports.
+	pub fn retry_after(&self) -> Option<std::time::Duration> {
+		match self {
+			Self::JsonRpcError(error) => error.retry_after(),
+			_ => None,
+		}
+	}
+
+	/// Returns the HTTP response status when this error carries one.
+	pub fn http_status(&self) -> Option<reqwest::StatusCode> {
+		match self {
+			Self::HTTPError(error) => error.status(),
+			_ => None,
+		}
+	}
+
+	/// Returns `true` when a Neo node does not know a polled transaction yet.
+	pub fn is_unknown_transaction(&self) -> bool {
+		matches!(self, Self::JsonRpcError(error) if error.is_unknown_transaction())
+	}
+
+	/// Returns `true` when a Neo node already has a submitted transaction.
+	pub fn is_already_known_transaction(&self) -> bool {
+		matches!(self, Self::JsonRpcError(error) if error.is_already_known_transaction())
+	}
+
+	/// Returns `true` for deterministic Neo transaction-submission rejections.
+	pub fn is_transaction_rejection(&self) -> bool {
+		matches!(self, Self::JsonRpcError(error) if error.is_transaction_rejection())
+	}
+}
+
+pub(crate) fn is_retryable_http_error(error: &reqwest::Error) -> bool {
+	if error.is_timeout() || error.is_request() || error.is_body() || error.is_decode() {
+		return true;
+	}
+
+	#[cfg(not(target_arch = "wasm32"))]
+	if error.is_connect() {
+		return true;
+	}
+
+	error.status().is_some_and(|status| {
+		status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
+	})
+}
+
 impl PartialEq for ProviderError {
 	fn eq(&self, other: &Self) -> bool {
 		match (self, other) {
@@ -116,6 +186,32 @@ impl Clone for ProviderError {
 			ProviderError::LockError => ProviderError::LockError,
 			ProviderError::ProtocolNotFound => ProviderError::ProtocolNotFound,
 			ProviderError::NetworkNotFound => ProviderError::NetworkNotFound,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn deterministic_provider_errors_are_not_retryable() {
+		assert!(!ProviderError::InvalidAddress.is_retryable());
+		assert!(!ProviderError::InvalidPassword.is_retryable());
+		assert!(!ProviderError::UnsupportedRPC.is_retryable());
+	}
+
+	#[test]
+	fn provider_preserves_unknown_transaction_classification() {
+		for code in [-100, -103, -105] {
+			let error = ProviderError::JsonRpcError(JsonRpcError {
+				code,
+				message: "transaction is not indexed yet".to_string(),
+				data: None,
+			});
+
+			assert!(error.is_unknown_transaction());
+			assert!(!error.is_retryable());
 		}
 	}
 }

--- a/src/neo_clients/rpc/transports/common.rs
+++ b/src/neo_clients/rpc/transports/common.rs
@@ -1,6 +1,6 @@
 // Code adapted from: https://github.com/althea-net/guac_rs/tree/master/web3/src/jsonrpc
 
-use std::fmt;
+use std::{fmt, time::Duration};
 
 use base64::{engine::general_purpose, Engine};
 use jsonwebtoken::{encode, errors::Error, get_current_timestamp, Algorithm, EncodingKey, Header};
@@ -14,8 +14,10 @@ use thiserror::Error;
 
 use neo3::prelude::Bytes;
 
+pub(crate) const MAX_PROVIDER_RETRY_AFTER: Duration = Duration::from_secs(60);
+
 /// A JSON-RPC 2.0 error
-#[derive(Deserialize, Debug, Clone, Error, PartialEq)]
+#[derive(Deserialize, Clone, Error, PartialEq)]
 pub struct JsonRpcError {
 	/// The error code
 	pub code: i64,
@@ -23,6 +25,16 @@ pub struct JsonRpcError {
 	pub message: String,
 	/// Additional data
 	pub data: Option<Value>,
+}
+
+impl fmt::Debug for JsonRpcError {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_struct("JsonRpcError")
+			.field("code", &self.code)
+			.field("message", &self.message)
+			.field("data", &self.data.as_ref().map(|_| "<redacted>"))
+			.finish()
+	}
 }
 
 /// Recursively traverses the value, looking for hex data that it can extract.
@@ -38,6 +50,69 @@ fn spelunk_revert(value: &Value) -> Option<Bytes> {
 }
 
 impl JsonRpcError {
+	/// Returns `true` when the provider indicates that the caller should retry after backoff.
+	pub fn is_retryable(&self) -> bool {
+		self.is_rate_limited()
+			|| self.code == -502
+			|| self.message.eq_ignore_ascii_case("header not found")
+			|| self
+				.message
+				.eq_ignore_ascii_case("daily request count exceeded, request rate limited")
+	}
+
+	/// Returns `true` for JSON-RPC responses that represent provider throttling.
+	pub fn is_rate_limited(&self) -> bool {
+		if matches!(self.code, 429 | -32005) {
+			return true;
+		}
+
+		(self.code == -32016
+			&& self
+				.message
+				.as_bytes()
+				.windows(b"rate limit".len())
+				.any(|window| window.eq_ignore_ascii_case(b"rate limit")))
+			|| self.retry_after().is_some()
+	}
+
+	/// Returns a provider-suggested delay before retrying, when present.
+	///
+	/// Untrusted hints are clamped to 60 seconds.
+	pub fn retry_after(&self) -> Option<Duration> {
+		let seconds = self.data.as_ref()?.get("rate")?.get("backoff_seconds")?;
+		if let Some(seconds) = seconds.as_u64() {
+			return Some(Duration::from_secs(seconds.min(MAX_PROVIDER_RETRY_AFTER.as_secs())));
+		}
+
+		let seconds = seconds.as_f64()?;
+		(seconds.is_finite() && seconds >= 0.0)
+			.then(|| seconds.ceil().min(MAX_PROVIDER_RETRY_AFTER.as_secs() as f64))
+			.map(|seconds| Duration::from_secs(seconds as u64))
+	}
+
+	/// Returns `true` when a Neo node reports that a transaction is not known yet.
+	///
+	/// Current Neo nodes use `-103` for an unknown transaction and `-105` for an unknown script
+	/// container; older nodes and gateways have also returned `-100`. These responses are useful
+	/// while polling for confirmation, but are not generally retryable request failures.
+	pub fn is_unknown_transaction(&self) -> bool {
+		matches!(self.code, -100 | -103 | -105)
+	}
+
+	/// Returns `true` when a Neo node reports that a submitted transaction is already known.
+	///
+	/// Neo uses `-501` when the transaction already exists in the ledger and `-503` when it is
+	/// already present in the memory pool. During rebroadcast, either response confirms that the
+	/// exact signed transaction reached the node.
+	pub fn is_already_known_transaction(&self) -> bool {
+		matches!(self.code, -501 | -503)
+	}
+
+	/// Returns `true` for deterministic Neo transaction-submission rejections.
+	pub fn is_transaction_rejection(&self) -> bool {
+		matches!(self.code, -500 | -504 | -505 | -507 | -508 | -509 | -510 | -511 | -512)
+	}
+
 	/// Determine if the error output of the `neo_call` RPC request is a revert
 	///
 	/// Note that this may return false positives if called on an error from
@@ -71,7 +146,7 @@ impl JsonRpcError {
 
 impl fmt::Display for JsonRpcError {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "(code: {}, message: {}, data: {:?})", self.code, self.message, self.data)
+		write!(f, "(code: {}, message: {})", self.code, self.message)
 	}
 }
 
@@ -393,6 +468,106 @@ pub struct Claims {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn classifies_transient_and_unknown_transaction_errors() {
+		let rate_limited =
+			JsonRpcError { code: -32016, message: "Rate limit exceeded".to_string(), data: None };
+		assert!(rate_limited.is_retryable());
+		assert!(!rate_limited.is_unknown_transaction());
+
+		for message in ["Header Not Found", "Daily Request Count Exceeded, Request Rate Limited"] {
+			let gateway_error =
+				JsonRpcError { code: -32000, message: message.to_string(), data: None };
+			assert!(gateway_error.is_retryable());
+		}
+
+		for (code, message) in [
+			(-100, "Unknown transaction/blockhash"),
+			(-103, "Unknown transaction"),
+			(-105, "Unknown script container"),
+		] {
+			let unknown_transaction =
+				JsonRpcError { code, message: message.to_string(), data: None };
+			assert!(!unknown_transaction.is_retryable());
+			assert!(unknown_transaction.is_unknown_transaction());
+		}
+
+		let invalid_request =
+			JsonRpcError { code: -32602, message: "Invalid params".to_string(), data: None };
+		assert!(!invalid_request.is_retryable());
+		assert!(!invalid_request.is_unknown_transaction());
+
+		for code in [-501, -503] {
+			let already_known =
+				JsonRpcError { code, message: "already known".to_string(), data: None };
+			assert!(already_known.is_already_known_transaction());
+			assert!(!already_known.is_transaction_rejection());
+		}
+
+		let pool_full = JsonRpcError {
+			code: -502,
+			message: "Memory pool capacity reached".to_string(),
+			data: None,
+		};
+		assert!(pool_full.is_retryable());
+		assert!(!pool_full.is_transaction_rejection());
+
+		for code in [-500, -504, -505, -511, -512] {
+			let rejected = JsonRpcError { code, message: "rejected".to_string(), data: None };
+			assert!(rejected.is_transaction_rejection());
+			assert!(!rejected.is_already_known_transaction());
+		}
+
+		let reserved = JsonRpcError { code: -506, message: "reserved".to_string(), data: None };
+		assert!(!reserved.is_transaction_rejection());
+	}
+
+	#[test]
+	fn extracts_non_negative_provider_backoff() {
+		for (value, expected) in [
+			(serde_json::json!(2), Some(Duration::from_secs(2))),
+			(serde_json::json!(1.1), Some(Duration::from_secs(2))),
+			(serde_json::json!(3_600), Some(Duration::from_secs(60))),
+			(serde_json::json!(-1), None),
+			(serde_json::json!("later"), None),
+		] {
+			let error = JsonRpcError {
+				code: 429,
+				message: "rate limited".to_string(),
+				data: Some(serde_json::json!({ "rate": { "backoff_seconds": value } })),
+			};
+			assert_eq!(error.retry_after(), expected);
+		}
+	}
+
+	#[test]
+	fn json_rpc_error_display_redacts_provider_data() {
+		let error = JsonRpcError {
+			code: -32000,
+			message: "request failed".to_string(),
+			data: Some(serde_json::json!({ "token": "super-secret" })),
+		};
+
+		let display = error.to_string();
+		assert!(display.contains("-32000"));
+		assert!(display.contains("request failed"));
+		assert!(!display.contains("super-secret"));
+	}
+
+	#[test]
+	fn json_rpc_error_debug_redacts_provider_data() {
+		let error = JsonRpcError {
+			code: -32000,
+			message: "request failed".to_string(),
+			data: Some(serde_json::json!({ "token": "super-secret" })),
+		};
+
+		let debug = format!("{error:?}");
+		assert!(debug.contains("-32000"));
+		assert!(debug.contains("request failed"));
+		assert!(!debug.contains("super-secret"));
+	}
 
 	#[test]
 	fn deser_response() {

--- a/src/neo_clients/rpc/transports/http_provider.rs
+++ b/src/neo_clients/rpc/transports/http_provider.rs
@@ -1,6 +1,9 @@
 // Code adapted from: https://github.com/althea-net/guac_rs/tree/master/web3/src/jsonrpc
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::{
+	sync::atomic::{AtomicU64, Ordering},
+	time::Duration,
+};
 
 use async_trait::async_trait;
 use futures_util::StreamExt;
@@ -11,7 +14,7 @@ use thiserror::Error;
 use tracing::debug;
 use url::Url;
 
-use super::common::{JsonRpcError, Request, Response};
+use super::common::{JsonRpcError, Request, Response, MAX_PROVIDER_RETRY_AFTER};
 use crate::neo_clients::{Authorization, JsonRpcProvider, ProviderError};
 use neo3::config::NeoConstants;
 
@@ -33,15 +36,38 @@ const MAX_ERROR_TEXT_BYTES: usize = 4 * 1024;
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug)]
 pub struct HttpProvider {
 	id: AtomicU64,
 	client: Client,
 	url: Url,
 }
 
+impl std::fmt::Debug for HttpProvider {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("HttpProvider")
+			.field("scheme", &self.url.scheme())
+			.field("host", &self.url.host_str())
+			.field("port", &self.url.port_or_known_default())
+			.finish_non_exhaustive()
+	}
+}
+
 #[derive(Error)]
 /// Error thrown when sending an HTTP request
+///
+/// The variants remain exhaustive for compatibility with NeoRust SDK 2.x clients.
+///
+/// ```no_run
+/// use neo3::neo_clients::HttpClientError;
+///
+/// fn classify(error: HttpClientError) -> &'static str {
+///     match error {
+///         HttpClientError::ReqwestError(_) => "transport",
+///         HttpClientError::JsonRpcError(_) => "json-rpc",
+///         HttpClientError::SerdeJson { .. } => "invalid-response",
+///     }
+/// }
+/// ```
 pub enum ClientError {
 	/// Thrown if the request failed
 	#[error(transparent)]
@@ -105,15 +131,35 @@ impl JsonRpcProvider for HttpProvider {
 		if let Some(timeout) = NeoConstants::rpc_request_timeout() {
 			request = request.timeout(timeout);
 		}
-		let res = request.send().await?;
+		let res = request
+			.send()
+			.await
+			.map_err(|error| ClientError::ReqwestError(error.without_url()))?;
+		let status_error = res.error_for_status_ref().err().map(reqwest::Error::without_url);
+		let retry_after = parse_retry_after(res.headers());
 		let max_response_size = NeoConstants::max_rpc_message_size();
-		let body =
-			collect_body_with_limit(res.content_length(), res.bytes_stream(), max_response_size)
-				.await?;
+		let body = match collect_body_with_limit(
+			res.content_length(),
+			res.bytes_stream(),
+			max_response_size,
+		)
+		.await
+		{
+			Ok(body) => body,
+			Err(error) => return Err(status_error.map_or(error, ClientError::ReqwestError)),
+		};
 
 		let raw = match serde_json::from_slice(&body) {
+			Ok(Response::Error { mut error, .. }) => {
+				attach_retry_after(&mut error, retry_after);
+				return Err(error.into());
+			},
+			_ if status_error.is_some() => {
+				return Err(ClientError::ReqwestError(
+					status_error.expect("status error checked above"),
+				))
+			},
 			Ok(Response::Success { result, .. }) => result.to_owned(),
-			Ok(Response::Error { error, .. }) => return Err(error.into()),
 			Ok(_) => {
 				let err = ClientError::SerdeJson {
 					err: serde::de::Error::custom("unexpected notification over HTTP transport"),
@@ -144,6 +190,44 @@ impl JsonRpcProvider for HttpProvider {
 	}
 }
 
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+	let seconds = headers
+		.get(reqwest::header::RETRY_AFTER)?
+		.to_str()
+		.ok()?
+		.trim()
+		.parse::<u64>()
+		.ok()?;
+	Some(Duration::from_secs(seconds.min(MAX_PROVIDER_RETRY_AFTER.as_secs())))
+}
+
+fn attach_retry_after(error: &mut JsonRpcError, retry_after: Option<Duration>) {
+	let Some(retry_after) = retry_after else {
+		return;
+	};
+	if error.retry_after().is_some() {
+		return;
+	}
+
+	let backoff = serde_json::Value::from(retry_after.as_secs());
+	match &mut error.data {
+		None => {
+			error.data = Some(serde_json::json!({
+				"rate": { "backoff_seconds": backoff }
+			}));
+		},
+		Some(serde_json::Value::Object(data)) => {
+			let rate = data
+				.entry("rate")
+				.or_insert_with(|| serde_json::Value::Object(Default::default()));
+			if let serde_json::Value::Object(rate) = rate {
+				rate.entry("backoff_seconds").or_insert(backoff);
+			}
+		},
+		Some(_) => {},
+	}
+}
+
 async fn collect_body_with_limit<S>(
 	content_length: Option<u64>,
 	mut stream: S,
@@ -167,7 +251,7 @@ where
 
 	let mut body: Vec<u8> = Vec::new();
 	while let Some(chunk) = stream.next().await {
-		let chunk = chunk.map_err(ClientError::ReqwestError)?;
+		let chunk = chunk.map_err(|error| ClientError::ReqwestError(error.without_url()))?;
 		if body.len().saturating_add(chunk.len()) > max_response_size {
 			let preview_len = body.len().min(MAX_ERROR_TEXT_BYTES);
 			return Err(ClientError::SerdeJson {
@@ -297,6 +381,150 @@ mod tests {
 		pin::Pin,
 		task::{Context, Poll},
 	};
+	use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+	async fn provider_returning_status(status: &str, body: &str) -> HttpProvider {
+		let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+		let address = listener.local_addr().unwrap();
+		let status = status.to_string();
+		let body = body.to_string();
+
+		tokio::spawn(async move {
+			let (mut stream, _) = listener.accept().await.unwrap();
+			let mut request = [0_u8; 2048];
+			let _ = stream.read(&mut request).await.unwrap();
+			let response = format!(
+				"HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+				body.len()
+			);
+			stream.write_all(response.as_bytes()).await.unwrap();
+		});
+
+		HttpProvider::new(Url::parse(&format!("http://{address}")).unwrap()).unwrap()
+	}
+
+	async fn provider_returning_response(response: String, path: &str) -> HttpProvider {
+		let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+		let address = listener.local_addr().unwrap();
+		tokio::spawn(async move {
+			let (mut stream, _) = listener.accept().await.unwrap();
+			let mut request = [0_u8; 2048];
+			let _ = stream.read(&mut request).await.unwrap();
+			stream.write_all(response.as_bytes()).await.unwrap();
+		});
+
+		HttpProvider::new(Url::parse(&format!("http://{address}{path}")).unwrap()).unwrap()
+	}
+
+	#[test]
+	fn provider_debug_redacts_url_credentials_and_paths() {
+		let provider = HttpProvider::new(
+			Url::parse("https://user:password@example.com/private/key?api_key=secret").unwrap(),
+		)
+		.unwrap();
+
+		let debug = format!("{provider:?}");
+		assert!(debug.contains("example.com"));
+		for secret in ["user", "password", "private", "api_key", "secret"] {
+			assert!(!debug.contains(secret), "debug output exposed {secret}: {debug}");
+		}
+	}
+
+	#[tokio::test]
+	async fn preserves_retryable_http_error_statuses() {
+		for (status, expected) in [("429 Too Many Requests", 429), ("503 Unavailable", 503)] {
+			let provider = provider_returning_status(status, "gateway unavailable").await;
+			let error = provider
+				.fetch::<_, serde_json::Value>("getblockcount", Vec::<u8>::new())
+				.await
+				.unwrap_err();
+			let provider_error: ProviderError = error.into();
+
+			assert_eq!(provider_error.http_status().map(|status| status.as_u16()), Some(expected));
+			assert!(provider_error.is_retryable());
+		}
+	}
+
+	#[tokio::test]
+	async fn sanitizes_status_error_urls_with_compatible_error_variant() {
+		let body = "rate limited";
+		let response = format!(
+			"HTTP/1.1 429 Too Many Requests\r\nContent-Length: {}\r\nRetry-After: 3600\r\nConnection: close\r\n\r\n{body}",
+			body.len()
+		);
+		let provider =
+			provider_returning_response(response, "/rpc?api_key=super-secret-value").await;
+		let error = provider
+			.fetch::<_, serde_json::Value>("getblockcount", Vec::<u8>::new())
+			.await
+			.unwrap_err();
+
+		assert!(matches!(
+			&error,
+			ClientError::ReqwestError(error)
+				if error.status() == Some(reqwest::StatusCode::TOO_MANY_REQUESTS)
+		));
+		let error: ProviderError = error.into();
+
+		assert!(error.is_rate_limited());
+		assert_eq!(error.retry_after(), None);
+		assert!(!error.to_string().contains("super-secret-value"));
+		assert!(!format!("{error:?}").contains("super-secret-value"));
+	}
+
+	#[tokio::test]
+	async fn preserves_json_rpc_errors_from_http_error_responses() {
+		let body = r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"project rate limit","data":null}}"#;
+		let response = format!(
+			"HTTP/1.1 429 Too Many Requests\r\nContent-Length: {}\r\nRetry-After: 5\r\nConnection: close\r\n\r\n{body}",
+			body.len()
+		);
+		let provider = provider_returning_response(response, "/").await;
+		let error: ProviderError = provider
+			.fetch::<_, serde_json::Value>("getblockcount", Vec::<u8>::new())
+			.await
+			.unwrap_err()
+			.into();
+
+		assert!(matches!(&error, ProviderError::JsonRpcError(JsonRpcError { code: -32000, .. })));
+		assert!(error.is_rate_limited());
+		assert_eq!(error.retry_after(), Some(Duration::from_secs(5)));
+	}
+
+	#[tokio::test]
+	async fn classifies_truncated_response_body_as_retryable() {
+		let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+		let address = listener.local_addr().unwrap();
+		let server = tokio::spawn(async move {
+			let (mut stream, _) = listener.accept().await.unwrap();
+			let mut request = [0_u8; 2048];
+			let _ = stream.read(&mut request).await.unwrap();
+			stream
+				.write_all(
+					b"HTTP/1.1 200 OK\r\nContent-Length: 128\r\nConnection: close\r\n\r\n{\"jsonrpc\":\"2.0\"}",
+				)
+				.await
+				.unwrap();
+		});
+
+		let provider =
+			HttpProvider::new(Url::parse(&format!("http://{address}")).unwrap()).unwrap();
+		let error = provider
+			.fetch::<_, serde_json::Value>("getblockcount", Vec::<u8>::new())
+			.await
+			.unwrap_err();
+		server.await.unwrap();
+		let provider_error: ProviderError = error.into();
+
+		assert!(
+			matches!(
+				&provider_error,
+				ProviderError::HTTPError(error) if error.is_body() || error.is_decode()
+			),
+			"expected a response body read error, got {provider_error:?}"
+		);
+		assert!(provider_error.is_retryable());
+	}
 
 	#[tokio::test]
 	async fn rejects_oversized_content_length_without_reading_body() {

--- a/src/neo_clients/rpc/transports/retry.rs
+++ b/src/neo_clients/rpc/transports/retry.rs
@@ -7,10 +7,12 @@ use std::{
 	time::Duration,
 };
 
-use super::{common::JsonRpcError, http_provider::ClientError};
+use super::{
+	common::{JsonRpcError, MAX_PROVIDER_RETRY_AFTER},
+	http_provider::ClientError,
+};
 use crate::neo_clients::{JsonRpcProvider, ProviderError};
 use async_trait::async_trait;
-use reqwest::StatusCode;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use thiserror::Error;
 use tracing::trace;
@@ -21,7 +23,9 @@ pub trait RetryPolicy<E>: Send + Sync + Debug {
 	/// Whether to retry the request based on the given `error`
 	fn should_retry(&self, error: &E) -> bool;
 
-	/// Providers may include the `backoff` in the error response directly
+	/// Providers may include the `backoff` in the error response directly.
+	///
+	/// The retry client caps hints to 60 seconds.
 	fn backoff_hint(&self, error: &E) -> Option<Duration>;
 }
 
@@ -155,7 +159,9 @@ impl RetryClientBuilder {
 		self
 	}
 
-	/// Sets the duration to wait initially before retrying
+	/// Sets the duration to wait initially before retrying.
+	///
+	/// Subsequent delays double up to a 60-second cap.
 	#[must_use]
 	pub fn initial_backoff(mut self, initial_backoff: Duration) -> Self {
 		self.initial_backoff = initial_backoff;
@@ -217,6 +223,46 @@ pub enum RetryClientError {
 	SerdeJson(serde_json::Error),
 }
 
+struct EnqueuedRequest<'a> {
+	counter: &'a AtomicU32,
+}
+
+impl<'a> EnqueuedRequest<'a> {
+	fn new(counter: &'a AtomicU32) -> (Self, u64) {
+		let ahead = u64::from(counter.fetch_add(1, Ordering::SeqCst));
+		(Self { counter }, ahead)
+	}
+}
+
+impl Drop for EnqueuedRequest<'_> {
+	fn drop(&mut self) {
+		self.counter.fetch_sub(1, Ordering::SeqCst);
+	}
+}
+
+fn retry_backoff(initial: Duration, retry_number: u32) -> Duration {
+	let exponent = retry_number.saturating_sub(1).min(u32::BITS - 1);
+	initial.saturating_mul(1_u32 << exponent).min(MAX_PROVIDER_RETRY_AFTER)
+}
+
+fn with_jitter(backoff: Duration) -> Duration {
+	let jitter_bound = u64::try_from(backoff.as_millis() / 4).unwrap_or(u64::MAX);
+	if jitter_bound == 0 {
+		return backoff;
+	}
+
+	let jitter = Duration::from_millis(rand::random::<u64>() % jitter_bound);
+	backoff.saturating_add(jitter).min(MAX_PROVIDER_RETRY_AFTER)
+}
+
+async fn sleep_backoff(backoff: Duration) {
+	#[cfg(target_arch = "wasm32")]
+	futures_timer::Delay::new(backoff).await;
+
+	#[cfg(not(target_arch = "wasm32"))]
+	tokio::time::sleep(backoff).await;
+}
+
 impl From<RetryClientError> for ProviderError {
 	fn from(src: RetryClientError) -> Self {
 		match src {
@@ -256,7 +302,7 @@ where
 			RetryParams::Value(params)
 		};
 
-		let ahead_in_queue = u64::from(self.requests_enqueued.fetch_add(1, Ordering::SeqCst));
+		let (_enqueued_request, ahead_in_queue) = EnqueuedRequest::new(&self.requests_enqueued);
 
 		let mut rate_limit_retry_number: u32 = 0;
 		let mut timeout_retries: u32 = 0;
@@ -272,10 +318,7 @@ where
 					RetryParams::Zst(unit) => self.inner.fetch(method, unit).await,
 				};
 				match resp {
-					Ok(ret) => {
-						self.requests_enqueued.fetch_sub(1, Ordering::SeqCst);
-						return Ok(ret);
-					},
+					Ok(ret) => return Ok(ret),
 					Err(err_) => err = err_,
 				}
 			}
@@ -293,11 +336,13 @@ where
 
 				// try to extract the requested backoff from the error or compute the next backoff
 				// based on retry count
-				let mut next_backoff = self.policy.backoff_hint(&err).unwrap_or_else(|| {
-					Duration::from_millis(
-						u64::try_from(self.initial_backoff.as_millis()).unwrap_or(u64::MAX),
-					)
-				});
+				let mut next_backoff = self
+					.policy
+					.backoff_hint(&err)
+					.map(|hint| hint.min(MAX_PROVIDER_RETRY_AFTER))
+					.unwrap_or_else(|| {
+						retry_backoff(self.initial_backoff, rate_limit_retry_number)
+					});
 
 				// requests are usually weighted and can vary from 10 CU to several 100 CU, cheaper
 				// requests are more common some example alchemy weights:
@@ -314,30 +359,25 @@ where
 					current_queued_requests,
 					ahead_in_queue,
 				);
-				next_backoff += Duration::from_secs(seconds_to_wait_for_compute_budget);
-
-				// Add jitter (up to 25% of backoff) to prevent thundering herd
-				let jitter_ms = (next_backoff.as_millis() as u64 / 4).max(1);
-				let jitter = Duration::from_millis(rand::random::<u64>() % jitter_ms);
-				next_backoff += jitter;
+				next_backoff = next_backoff
+					.saturating_add(Duration::from_secs(seconds_to_wait_for_compute_budget))
+					.min(MAX_PROVIDER_RETRY_AFTER);
+				next_backoff = with_jitter(next_backoff);
 
 				trace!("retrying and backing off for {:?}", next_backoff);
-
-				#[cfg(target_arch = "wasm32")]
-				futures_timer::Delay::new(next_backoff).await;
-
-				#[cfg(not(target_arch = "wasm32"))]
-				tokio::time::sleep(next_backoff).await;
+				sleep_backoff(next_backoff).await;
 			} else {
 				let err: ProviderError = err.into();
 				if timeout_retries < self.timeout_retries && maybe_connectivity(&err) {
 					timeout_retries += 1;
-					trace!(err = ?err, "retrying due to spurious network");
+					let next_backoff =
+						with_jitter(retry_backoff(self.initial_backoff, timeout_retries));
+					trace!(error = %err, delay = ?next_backoff, "retrying due to spurious network");
+					sleep_backoff(next_backoff).await;
 					continue;
 				}
 
-				trace!(err = ?err, "should not retry");
-				self.requests_enqueued.fetch_sub(1, Ordering::SeqCst);
+				trace!(error = %err, "should not retry");
 				return Err(RetryClientError::ProviderError(err));
 			}
 		}
@@ -354,32 +394,11 @@ pub struct HttpRateLimitRetryPolicy;
 
 impl RetryPolicy<ClientError> for HttpRateLimitRetryPolicy {
 	fn should_retry(&self, error: &ClientError) -> bool {
-		fn should_retry_json_rpc_error(err: &JsonRpcError) -> bool {
-			let JsonRpcError { code, message, .. } = err;
-			// Some gateways surface rate limits as JSON-RPC code 429.
-			if *code == 429 {
-				return true;
-			}
-
-			// Some gateways use -32005 for "exceeded project rate limit".
-			if *code == -32005 {
-				return true;
-			}
-
-			// Some gateways use -32016 + "rate limit" in the message (e.g., per-IP throttling).
-			if *code == -32016 && message.contains("rate limit") {
-				return true;
-			}
-
-			matches!(
-				message.as_str(),
-				"header not found" | "daily request count exceeded, request rate limited"
-			)
-		}
-
 		match error {
-			ClientError::ReqwestError(err) => err.status() == Some(StatusCode::TOO_MANY_REQUESTS),
-			ClientError::JsonRpcError(err) => should_retry_json_rpc_error(err),
+			ClientError::ReqwestError(err) => {
+				err.status() == Some(reqwest::StatusCode::TOO_MANY_REQUESTS)
+			},
+			ClientError::JsonRpcError(err) => err.is_retryable(),
 			ClientError::SerdeJson { text, .. } => {
 				// some providers send invalid JSON RPC in the error case (no `id:u64`), but the
 				// text should be a `JsonRpcError`
@@ -389,7 +408,7 @@ impl RetryPolicy<ClientError> for HttpRateLimitRetryPolicy {
 				}
 
 				if let Ok(resp) = serde_json::from_str::<Resp>(text) {
-					return should_retry_json_rpc_error(&resp.error);
+					return resp.error.is_retryable();
 				}
 				false
 			},
@@ -397,20 +416,10 @@ impl RetryPolicy<ClientError> for HttpRateLimitRetryPolicy {
 	}
 
 	fn backoff_hint(&self, error: &ClientError) -> Option<Duration> {
-		if let ClientError::JsonRpcError(JsonRpcError { data, .. }) = error {
-			let data = data.as_ref()?;
-
-			// Some gateways include a recommended backoff in the error payload.
-			let backoff_seconds = &data["rate"]["backoff_seconds"];
-			if let Some(seconds) = backoff_seconds.as_u64() {
-				return Some(Duration::from_secs(seconds));
-			}
-			if let Some(seconds) = backoff_seconds.as_f64() {
-				return Some(Duration::from_secs(seconds.max(0.0).ceil() as u64));
-			}
+		match error {
+			ClientError::JsonRpcError(error) => error.retry_after(),
+			_ => None,
 		}
-
-		None
 	}
 }
 
@@ -431,7 +440,8 @@ fn compute_unit_offset_in_secs(
 	current_queued_requests: u64,
 	ahead_in_queue: u64,
 ) -> u64 {
-	let request_capacity_per_second = compute_units_per_second.saturating_div(avg_cost);
+	let request_capacity_per_second =
+		compute_units_per_second.checked_div(avg_cost).unwrap_or_default().max(1);
 	if current_queued_requests > request_capacity_per_second {
 		current_queued_requests
 			.min(ahead_in_queue)
@@ -444,30 +454,15 @@ fn compute_unit_offset_in_secs(
 /// Checks whether the `error` is the result of a connectivity issue, like
 /// `request::Error::TimedOut`
 fn maybe_connectivity(err: &ProviderError) -> bool {
-	if let ProviderError::HTTPError(reqwest_err) = err {
-		if reqwest_err.is_timeout() {
-			return true;
-		}
-
-		#[cfg(not(target_arch = "wasm32"))]
-		if reqwest_err.is_connect() {
-			return true;
-		}
-
-		// Error HTTP codes (5xx) are considered connectivity issues and will prompt retry
-		if let Some(status) = reqwest_err.status() {
-			let code = status.as_u16();
-			if (500..600).contains(&code) {
-				return true;
-			}
-		}
-	}
-	false
+	matches!(err, ProviderError::HTTPError(_)) && err.is_retryable()
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::neo_clients::HttpProvider;
+	use tokio::io::{AsyncReadExt, AsyncWriteExt};
+	use url::Url;
 
 	// assumed average cost of a request
 	const AVG_COST: u64 = 17u64;
@@ -517,6 +512,104 @@ mod tests {
 		let to_wait = compute_offset(current_queued_requests, ahead_in_queue);
 		// need to wait 1 second
 		assert_eq!(to_wait, 1);
+	}
+
+	#[test]
+	fn zero_compute_units_do_not_panic() {
+		assert_eq!(compute_unit_offset_in_secs(AVG_COST, 0, 1, 0), 0);
+		assert_eq!(compute_unit_offset_in_secs(AVG_COST, 0, 3, 2), 2);
+	}
+
+	#[test]
+	fn exponential_backoff_doubles_and_caps() {
+		let initial = Duration::from_millis(500);
+		assert_eq!(retry_backoff(initial, 1), Duration::from_millis(500));
+		assert_eq!(retry_backoff(initial, 2), Duration::from_secs(1));
+		assert_eq!(retry_backoff(initial, 8), Duration::from_secs(60));
+		assert_eq!(retry_backoff(initial, u32::MAX), Duration::from_secs(60));
+	}
+
+	async fn retry_client_for_responses(
+		responses: Vec<String>,
+	) -> (RetryClient<HttpProvider>, tokio::task::JoinHandle<()>) {
+		retry_client_for_responses_with_backoff(responses, Duration::ZERO).await
+	}
+
+	async fn retry_client_for_responses_with_backoff(
+		responses: Vec<String>,
+		initial_backoff: Duration,
+	) -> (RetryClient<HttpProvider>, tokio::task::JoinHandle<()>) {
+		let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+		let address = listener.local_addr().unwrap();
+		let server = tokio::spawn(async move {
+			for response in responses {
+				let (mut stream, _) = listener.accept().await.unwrap();
+				let mut request = [0_u8; 2048];
+				let _ = stream.read(&mut request).await.unwrap();
+				stream.write_all(response.as_bytes()).await.unwrap();
+			}
+		});
+		let provider =
+			HttpProvider::new(Url::parse(&format!("http://{address}")).unwrap()).unwrap();
+		let client = RetryClientBuilder::default()
+			.timeout_retries(1)
+			.rate_limit_retries(0)
+			.initial_backoff(initial_backoff)
+			.build(provider, Box::<HttpRateLimitRetryPolicy>::default());
+		(client, server)
+	}
+
+	#[tokio::test]
+	async fn retries_truncated_response_then_succeeds() {
+		let truncated = "HTTP/1.1 200 OK\r\nContent-Length: 128\r\nConnection: close\r\n\r\n{\"jsonrpc\":\"2.0\"}".to_string();
+		let body = r#"{"jsonrpc":"2.0","id":2,"result":42}"#;
+		let success = format!(
+			"HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+			body.len()
+		);
+		let (client, server) = retry_client_for_responses(vec![truncated, success]).await;
+
+		let result: u64 = client.fetch("getblockcount", Vec::<u8>::new()).await.unwrap();
+
+		assert_eq!(result, 42);
+		server.await.unwrap();
+	}
+
+	#[tokio::test]
+	async fn connectivity_retries_wait_before_retrying() {
+		let truncated = "HTTP/1.1 200 OK\r\nContent-Length: 128\r\nConnection: close\r\n\r\n{\"jsonrpc\":\"2.0\"}".to_string();
+		let body = r#"{"jsonrpc":"2.0","id":2,"result":42}"#;
+		let success = format!(
+			"HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+			body.len()
+		);
+		let initial_backoff = Duration::from_millis(25);
+		let (client, server) =
+			retry_client_for_responses_with_backoff(vec![truncated, success], initial_backoff)
+				.await;
+		let started = tokio::time::Instant::now();
+
+		let result: u64 = client.fetch("getblockcount", Vec::<u8>::new()).await.unwrap();
+
+		assert_eq!(result, 42);
+		assert!(started.elapsed() >= initial_backoff);
+		server.await.unwrap();
+	}
+
+	#[tokio::test]
+	async fn retry_exhaustion_releases_queue_accounting() {
+		let body = "rate limited";
+		let response = format!(
+			"HTTP/1.1 429 Too Many Requests\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+			body.len()
+		);
+		let (client, server) = retry_client_for_responses(vec![response]).await;
+
+		let result = client.fetch::<_, serde_json::Value>("getblockcount", Vec::<u8>::new()).await;
+
+		assert!(matches!(result, Err(RetryClientError::TimeoutError)));
+		assert_eq!(client.requests_enqueued.load(Ordering::SeqCst), 0);
+		server.await.unwrap();
 	}
 
 	#[test]

--- a/src/neo_contract/mod.rs
+++ b/src/neo_contract/mod.rs
@@ -148,5 +148,34 @@ mod role_management;
 mod traits;
 mod treasury;
 
+pub(crate) fn checked_vm_integer<T>(value: i64, field: &str) -> Result<T, ContractError>
+where
+	T: TryFrom<i64>,
+{
+	T::try_from(value).map_err(|_| {
+		ContractError::InvalidResponse(format!(
+			"{field} value {value} is outside the supported range"
+		))
+	})
+}
+
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod checked_integer_tests {
+	use super::*;
+
+	#[test]
+	fn checked_vm_integer_rejects_negative_and_oversized_values() {
+		assert!(matches!(
+			checked_vm_integer::<u32>(-1, "block height"),
+			Err(ContractError::InvalidResponse(message)) if message.contains("block height")
+		));
+		assert!(matches!(
+			checked_vm_integer::<u8>(256, "decimals"),
+			Err(ContractError::InvalidResponse(message)) if message.contains("decimals")
+		));
+		assert_eq!(checked_vm_integer::<u32>(42, "block height").unwrap(), 42);
+	}
+}

--- a/src/neo_contract/name_service.rs
+++ b/src/neo_contract/name_service.rs
@@ -5,7 +5,8 @@ use crate::{
 	deserialize_script_hash, deserialize_script_hash_option,
 	neo_clients::{APITrait, JsonRpcProvider, RpcClient},
 	neo_contract::{
-		ContractError, NeoIterator, NonFungibleTokenTrait, SmartContractTrait, TokenTrait,
+		checked_vm_integer, ContractError, NeoIterator, NonFungibleTokenTrait, SmartContractTrait,
+		TokenTrait,
 	},
 	serialize_script_hash, serialize_script_hash_option, ContractParameter, NNSName, ScriptHash,
 	ScriptHashExtension, StackItem,
@@ -243,7 +244,8 @@ impl<'a, P: JsonRpcProvider + 'static> NeoNameService<'a, P> {
 				"Invalid {} property type",
 				Self::EXPIRATION_PROPERTY
 			))
-		})? as u32;
+		})?;
+		let expiration = checked_vm_integer(expiration, "NNS expiration")?;
 
 		// Find the admin property in the map
 		let admin_key = StackItem::ByteString { value: Self::ADMIN_PROPERTY.to_string() };

--- a/src/neo_contract/notary.rs
+++ b/src/neo_contract/notary.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
 	neo_builder::TransactionBuilder,
 	neo_clients::{JsonRpcProvider, RpcClient},
-	neo_contract::{traits::SmartContractTrait, ContractError},
+	neo_contract::{checked_vm_integer, traits::SmartContractTrait, ContractError},
 	neo_types::{
 		serde_with_utils::{deserialize_script_hash, serialize_script_hash},
 		ScriptHash, StackItem,
@@ -38,7 +38,11 @@ impl NotaryDeposit {
 			StackItem::Struct { value } | StackItem::Array { value } if value.len() >= 2 => {
 				let amount = value[0].as_int().ok_or_else(|| "Invalid amount".to_string())?;
 
-				let till = value[1].as_int().ok_or_else(|| "Invalid till".to_string())? as u32;
+				let till = value[1]
+					.as_int()
+					.ok_or_else(|| "Invalid till".to_string())?
+					.try_into()
+					.map_err(|_| "Invalid till: value is outside the u32 range".to_string())?;
 
 				Ok(Self { amount, till })
 			},
@@ -91,7 +95,7 @@ impl<'a, P: JsonRpcProvider + 'static> NotaryContract<'a, P> {
 	///
 	/// The amount of GAS deposited by the account (in smallest units, 1 GAS = 10^8).
 	pub async fn balance_of(&self, account: &H160) -> Result<i64, ContractError> {
-		Ok(self.call_function_returning_int("balanceOf", vec![account.into()]).await? as i64)
+		self.call_function_returning_int("balanceOf", vec![account.into()]).await
 	}
 
 	/// Gets the deposit lock expiration height for the specified account.
@@ -105,7 +109,10 @@ impl<'a, P: JsonRpcProvider + 'static> NotaryContract<'a, P> {
 	/// The block height at which the deposit can be withdrawn.
 	/// Returns 0 if no deposit exists.
 	pub async fn expiration_of(&self, account: &H160) -> Result<u32, ContractError> {
-		Ok(self.call_function_returning_int("expirationOf", vec![account.into()]).await? as u32)
+		checked_vm_integer(
+			self.call_function_returning_int("expirationOf", vec![account.into()]).await?,
+			"notary deposit expiration",
+		)
 	}
 
 	/// Gets the maximum NotValidBefore delta value.
@@ -117,7 +124,10 @@ impl<'a, P: JsonRpcProvider + 'static> NotaryContract<'a, P> {
 	///
 	/// The maximum NotValidBefore delta in blocks.
 	pub async fn get_max_not_valid_before_delta(&self) -> Result<u32, ContractError> {
-		Ok(self.call_function_returning_int("getMaxNotValidBeforeDelta", vec![]).await? as u32)
+		checked_vm_integer(
+			self.call_function_returning_int("getMaxNotValidBeforeDelta", vec![]).await?,
+			"maximum not-valid-before delta",
+		)
 	}
 
 	/// Locks the deposit until the specified block height.
@@ -252,5 +262,16 @@ mod tests {
 		let deposit = NotaryDeposit::from_stack_item(&item).unwrap();
 		assert_eq!(deposit.amount, 1000000000i64);
 		assert_eq!(deposit.till, 100000);
+	}
+
+	#[test]
+	fn notary_deposit_rejects_invalid_block_height() {
+		for till in [-1_i64, i64::from(u32::MAX) + 1] {
+			let item = StackItem::Struct {
+				value: vec![StackItem::Integer { value: 1 }, StackItem::Integer { value: till }],
+			};
+
+			assert!(NotaryDeposit::from_stack_item(&item).is_err());
+		}
 	}
 }

--- a/src/neo_contract/policy_contract.rs
+++ b/src/neo_contract/policy_contract.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use crate::{
 	neo_builder::TransactionBuilder,
 	neo_clients::{JsonRpcProvider, RpcClient},
-	neo_contract::{traits::SmartContractTrait, ContractError, NeoIterator},
+	neo_contract::{checked_vm_integer, traits::SmartContractTrait, ContractError, NeoIterator},
 	neo_types::{
 		serde_with_utils::{deserialize_script_hash, serialize_script_hash},
 		ScriptHash, StackItem, WhitelistedContract,
@@ -87,7 +87,7 @@ impl<'a, P: JsonRpcProvider + 'static> PolicyContract<'a, P> {
 
 	/// Gets the network fee per transaction byte (in datoshi).
 	pub async fn get_fee_per_byte(&self) -> Result<i64, ContractError> {
-		Ok(self.call_function_returning_int("getFeePerByte", vec![]).await? as i64)
+		self.call_function_returning_int("getFeePerByte", vec![]).await
 	}
 
 	/// Gets the execution fee factor.
@@ -96,19 +96,25 @@ impl<'a, P: JsonRpcProvider + 'static> PolicyContract<'a, P> {
 	/// After HF_Faun, this returns the factor without decimals (use `get_exec_pico_fee_factor`
 	/// for the full precision value).
 	pub async fn get_exec_fee_factor(&self) -> Result<u32, ContractError> {
-		Ok(self.call_function_returning_int("getExecFeeFactor", vec![]).await? as u32)
+		checked_vm_integer(
+			self.call_function_returning_int("getExecFeeFactor", vec![]).await?,
+			"execution fee factor",
+		)
 	}
 
 	/// Gets the execution fee factor in pico-GAS (1 pico-GAS = 1e-12 GAS).
 	///
 	/// This method is available after HF_Faun and returns the fee factor with full decimal precision.
 	pub async fn get_exec_pico_fee_factor(&self) -> Result<i64, ContractError> {
-		Ok(self.call_function_returning_int("getExecPicoFeeFactor", vec![]).await? as i64)
+		self.call_function_returning_int("getExecPicoFeeFactor", vec![]).await
 	}
 
 	/// Gets the storage price (cost per byte of storage).
 	pub async fn get_storage_price(&self) -> Result<u32, ContractError> {
-		Ok(self.call_function_returning_int("getStoragePrice", vec![]).await? as u32)
+		checked_vm_integer(
+			self.call_function_returning_int("getStoragePrice", vec![]).await?,
+			"storage price",
+		)
 	}
 
 	// ========== Block Time and Limits (HF_Echidna) ==========
@@ -117,7 +123,10 @@ impl<'a, P: JsonRpcProvider + 'static> PolicyContract<'a, P> {
 	///
 	/// This method is available after HF_Echidna.
 	pub async fn get_milliseconds_per_block(&self) -> Result<u32, ContractError> {
-		Ok(self.call_function_returning_int("getMillisecondsPerBlock", vec![]).await? as u32)
+		checked_vm_integer(
+			self.call_function_returning_int("getMillisecondsPerBlock", vec![]).await?,
+			"milliseconds per block",
+		)
 	}
 
 	/// Sets the block generation time in milliseconds.
@@ -137,9 +146,11 @@ impl<'a, P: JsonRpcProvider + 'static> PolicyContract<'a, P> {
 	///
 	/// This method is available after HF_Echidna.
 	pub async fn get_max_valid_until_block_increment(&self) -> Result<u32, ContractError> {
-		Ok(self
-			.call_function_returning_int("getMaxValidUntilBlockIncrement", vec![])
-			.await? as u32)
+		checked_vm_integer(
+			self.call_function_returning_int("getMaxValidUntilBlockIncrement", vec![])
+				.await?,
+			"maximum valid-until-block increment",
+		)
 	}
 
 	/// Sets the maximum ValidUntilBlock increment.
@@ -160,7 +171,10 @@ impl<'a, P: JsonRpcProvider + 'static> PolicyContract<'a, P> {
 	///
 	/// This method is available after HF_Echidna.
 	pub async fn get_max_traceable_blocks(&self) -> Result<u32, ContractError> {
-		Ok(self.call_function_returning_int("getMaxTraceableBlocks", vec![]).await? as u32)
+		checked_vm_integer(
+			self.call_function_returning_int("getMaxTraceableBlocks", vec![]).await?,
+			"maximum traceable blocks",
+		)
 	}
 
 	/// Sets the maximum number of traceable blocks.
@@ -187,9 +201,11 @@ impl<'a, P: JsonRpcProvider + 'static> PolicyContract<'a, P> {
 	///
 	/// * `attribute_type` - The transaction attribute type (as a byte value).
 	pub async fn get_attribute_fee(&self, attribute_type: u8) -> Result<u32, ContractError> {
-		Ok(self
-			.call_function_returning_int("getAttributeFee", vec![attribute_type.into()])
-			.await? as u32)
+		checked_vm_integer(
+			self.call_function_returning_int("getAttributeFee", vec![attribute_type.into()])
+				.await?,
+			"attribute fee",
+		)
 	}
 
 	/// Sets the fee for a specific transaction attribute type.
@@ -250,6 +266,7 @@ impl<'a, P: JsonRpcProvider + 'static> PolicyContract<'a, P> {
 		&self,
 		batch_size: usize,
 	) -> Result<Vec<H160>, ContractError> {
+		let batch_size = Self::checked_iterator_batch_size(batch_size)?;
 		let iterator = self.get_blocked_accounts().await?;
 		self.collect_all(iterator, batch_size).await
 	}
@@ -373,26 +390,33 @@ impl<'a, P: JsonRpcProvider + 'static> PolicyContract<'a, P> {
 		&self,
 		batch_size: usize,
 	) -> Result<Vec<WhitelistedContract>, ContractError> {
+		let batch_size = Self::checked_iterator_batch_size(batch_size)?;
 		let iterator = self.get_whitelist_fee_contracts().await?;
 		self.collect_all(iterator, batch_size).await
 	}
 
-	async fn collect_all<T>(
-		&self,
-		iterator: NeoIterator<'_, T, P>,
-		batch_size: usize,
-	) -> Result<Vec<T>, ContractError> {
+	fn checked_iterator_batch_size(batch_size: usize) -> Result<i32, ContractError> {
 		if batch_size == 0 {
 			return Err(ContractError::InvalidArgError(
 				"Batch size must be greater than zero".to_string(),
 			));
 		}
 
+		i32::try_from(batch_size).map_err(|_| {
+			ContractError::InvalidArgError(format!("Batch size must not exceed {}", i32::MAX))
+		})
+	}
+
+	async fn collect_all<T>(
+		&self,
+		iterator: NeoIterator<'_, T, P>,
+		batch_size: i32,
+	) -> Result<Vec<T>, ContractError> {
 		let mut all_items = Vec::new();
 		let mut traverse_error: Option<ContractError> = None;
 
 		loop {
-			match iterator.traverse(batch_size as i32).await {
+			match iterator.traverse(batch_size).await {
 				Ok(batch) => {
 					if batch.is_empty() {
 						break;
@@ -601,5 +625,33 @@ mod tests {
 			Err(ContractError::UnexpectedReturnType(message))
 				if message.contains("WhitelistedContract")
 		));
+	}
+
+	#[tokio::test]
+	async fn blocked_accounts_reject_invalid_batch_sizes_before_opening_iterator() {
+		for batch_size in [0, i32::MAX as usize + 1] {
+			let provider = MockProvider::new();
+			let client = RpcClient::new(provider.clone());
+			let contract = PolicyContract::new(Some(&client));
+
+			let result = contract.get_blocked_accounts_all_with_batch(batch_size).await;
+
+			assert!(matches!(result, Err(ContractError::InvalidArgError(_))));
+			assert!(provider.take_requests().is_empty());
+		}
+	}
+
+	#[tokio::test]
+	async fn whitelist_rejects_invalid_batch_sizes_before_opening_iterator() {
+		for batch_size in [0, i32::MAX as usize + 1] {
+			let provider = MockProvider::new();
+			let client = RpcClient::new(provider.clone());
+			let contract = PolicyContract::new(Some(&client));
+
+			let result = contract.get_whitelist_fee_contracts_all_with_batch(batch_size).await;
+
+			assert!(matches!(result, Err(ContractError::InvalidArgError(_))));
+			assert!(provider.take_requests().is_empty());
+		}
 	}
 }

--- a/src/neo_contract/traits/smart_contract.rs
+++ b/src/neo_contract/traits/smart_contract.rs
@@ -243,11 +243,16 @@ pub trait SmartContractTrait<'a>: Send + Sync {
 		_max_items: usize,
 		mapper: impl Fn(StackItem) -> Result<U, ContractError> + Send,
 	) -> Result<Vec<U>, ContractError> {
+		let max_items = u32::try_from(_max_items).map_err(|_| {
+			ContractError::InvalidArgError(format!(
+				"Iterator item limit {_max_items} exceeds the supported u32 range"
+			))
+		})?;
 		let script = ScriptBuilder::build_contract_call_and_unwrap_iterator(
 			&self.script_hash(),
 			function,
 			&params,
-			_max_items as u32, // Use the max_items parameter provided to the function
+			max_items,
 			Some(CallFlags::All),
 		)
 		.map_err(|e| {

--- a/src/neo_contract/traits/token.rs
+++ b/src/neo_contract/traits/token.rs
@@ -5,7 +5,7 @@ use rust_decimal::Decimal;
 
 use crate::{
 	neo_clients::JsonRpcProvider,
-	neo_contract::{ContractError, SmartContractTrait},
+	neo_contract::{checked_vm_integer, ContractError, SmartContractTrait},
 	neo_types::NNSName,
 };
 
@@ -32,7 +32,10 @@ pub trait TokenTrait<'a, P: JsonRpcProvider>: SmartContractTrait<'a, P = P> {
 			return Ok(*supply);
 		}
 
-		let supply = self.call_function_returning_int(Self::TOTAL_SUPPLY, vec![]).await? as u64;
+		let supply = checked_vm_integer(
+			self.call_function_returning_int(Self::TOTAL_SUPPLY, vec![]).await?,
+			"token total supply",
+		)?;
 
 		self.set_total_supply(supply);
 		Ok(supply)
@@ -43,7 +46,10 @@ pub trait TokenTrait<'a, P: JsonRpcProvider>: SmartContractTrait<'a, P = P> {
 			return Ok(*decimals);
 		}
 
-		let decimals = self.call_function_returning_int(Self::DECIMALS, vec![]).await? as u8;
+		let decimals = checked_vm_integer(
+			self.call_function_returning_int(Self::DECIMALS, vec![]).await?,
+			"token decimals",
+		)?;
 
 		self.set_decimals(decimals);
 		Ok(decimals)

--- a/src/neo_error/unified.rs
+++ b/src/neo_error/unified.rs
@@ -300,6 +300,77 @@ pub enum NeoErrorKind {
 }
 
 impl NeoError {
+	/// Convert a provider error while preserving whether it is transient and which SDK domain it
+	/// belongs to.
+	pub fn provider(context: &str, err: crate::neo_clients::ProviderError) -> Self {
+		use crate::neo_clients::ProviderError;
+
+		let message = format!("{}: {}", context, err);
+		if err.is_rate_limited() {
+			let retry_after = err.retry_after();
+			let mut recovery = ErrorRecovery::new()
+				.suggest("Retry after backing off")
+				.suggest("Reduce request concurrency")
+				.retryable(true);
+			if let Some(delay) = retry_after {
+				recovery = recovery.retry_after(delay);
+			}
+			return NeoError::RateLimit { message, retry_after, recovery };
+		}
+
+		let retryable = err.is_retryable();
+		match err {
+			ProviderError::InvalidAddress => NeoError::Validation {
+				message,
+				field: "address".to_string(),
+				value: None,
+				recovery: ErrorRecovery::new().suggest("Provide a valid Neo address"),
+			},
+			ProviderError::NnsError(_) | ProviderError::NnsNotOwned(_) => NeoError::Validation {
+				message,
+				field: "name".to_string(),
+				value: None,
+				recovery: ErrorRecovery::new().suggest("Check the NNS name and ownership"),
+			},
+			ProviderError::TypeError(_) => NeoError::Validation {
+				message,
+				field: "provider_input".to_string(),
+				value: None,
+				recovery: ErrorRecovery::new().suggest("Check the provider request values"),
+			},
+			ProviderError::InvalidPassword
+			| ProviderError::SignerUnavailable
+			| ProviderError::CryptoError(_) => NeoError::Wallet {
+				message,
+				source: None,
+				recovery: ErrorRecovery::new().suggest("Check wallet credentials and signer setup"),
+			},
+			ProviderError::UnsupportedRPC
+			| ProviderError::UnsupportedNodeClient
+			| ProviderError::ProtocolNotFound
+			| ProviderError::NetworkNotFound => NeoError::Configuration {
+				message,
+				field: Some("provider".to_string()),
+				recovery: ErrorRecovery::new()
+					.suggest("Use an endpoint that supports the requested RPC operation"),
+			},
+			error @ (ProviderError::HTTPError(_) | ProviderError::JsonRpcError(_)) => {
+				NeoError::Network {
+					message,
+					source: Some(Box::new(error)),
+					recovery: ErrorRecovery::new()
+						.suggest("Check network connectivity and the RPC endpoint")
+						.retryable(retryable),
+				}
+			},
+			error => NeoError::Other {
+				message,
+				source: Some(Box::new(error)),
+				recovery: ErrorRecovery::new(),
+			},
+		}
+	}
+
 	/// Returns the coarse [`NeoErrorKind`] for this error.
 	///
 	/// Stable across non-exhaustive variant additions — prefer this in
@@ -963,16 +1034,27 @@ impl From<crate::neo_types::TypeError> for NeoError {
 	}
 }
 
+impl From<crate::codec::CodecError> for NeoError {
+	fn from(err: crate::codec::CodecError) -> Self {
+		match err {
+			crate::codec::CodecError::InvalidPassphrase(message) => NeoError::Wallet {
+				message: format!("Invalid passphrase: {message}"),
+				source: None,
+				recovery: ErrorRecovery::new().suggest("Verify the wallet passphrase"),
+			},
+			other => NeoError::Validation {
+				message: other.to_string(),
+				field: "encoded_data".to_string(),
+				value: None,
+				recovery: ErrorRecovery::new().suggest("Verify the encoded data format"),
+			},
+		}
+	}
+}
+
 impl From<crate::neo_clients::ProviderError> for NeoError {
 	fn from(err: crate::neo_clients::ProviderError) -> Self {
-		NeoError::Network {
-			message: err.to_string(),
-			source: None,
-			recovery: ErrorRecovery::new()
-				.suggest("Check network connectivity")
-				.suggest("Verify the RPC endpoint is accessible")
-				.retryable(true),
-		}
+		NeoError::provider("provider request failed", err)
 	}
 }
 
@@ -1152,6 +1234,61 @@ mod tests {
 		let err = NeoError::validation("amount", Some("-1"), "must be positive");
 		assert_eq!(err.kind(), NeoErrorKind::Validation);
 		assert!(!err.is_retryable());
+	}
+
+	#[test]
+	fn provider_conversion_preserves_retry_and_domain_classification() {
+		let invalid_address = NeoError::from(crate::neo_clients::ProviderError::InvalidAddress);
+		assert_eq!(invalid_address.kind(), NeoErrorKind::Validation);
+		assert!(!invalid_address.is_retryable());
+
+		let rate_limited = NeoError::from(crate::neo_clients::ProviderError::JsonRpcError(
+			crate::neo_clients::JsonRpcError {
+				code: 429,
+				message: "too many requests".to_string(),
+				data: None,
+			},
+		));
+		assert_eq!(rate_limited.kind(), NeoErrorKind::RateLimit);
+		assert!(rate_limited.is_retryable());
+
+		let rate_limited = NeoError::from(crate::neo_clients::ProviderError::JsonRpcError(
+			crate::neo_clients::JsonRpcError {
+				code: 429,
+				message: "too many requests".to_string(),
+				data: Some(serde_json::json!({ "rate": { "backoff_seconds": 2 } })),
+			},
+		));
+		assert_eq!(rate_limited.retry_after(), Some(std::time::Duration::from_secs(2)));
+	}
+
+	#[test]
+	fn provider_debug_redacts_json_rpc_data_through_unified_error() {
+		let error = NeoError::from(crate::neo_clients::ProviderError::JsonRpcError(
+			crate::neo_clients::JsonRpcError {
+				code: -32000,
+				message: "provider rejected request".to_string(),
+				data: Some(serde_json::json!({ "token": "super-secret" })),
+			},
+		));
+
+		let debug = format!("{error:?}");
+		assert!(debug.contains("provider rejected request"));
+		assert!(!debug.contains("super-secret"));
+	}
+
+	#[test]
+	fn codec_errors_convert_into_the_unified_boundary() {
+		let malformed = NeoError::from(crate::codec::CodecError::InvalidEncoding(
+			"truncated payload".to_string(),
+		));
+		assert_eq!(malformed.kind(), NeoErrorKind::Validation);
+		assert!(!malformed.is_retryable());
+
+		let passphrase = NeoError::from(crate::codec::CodecError::InvalidPassphrase(
+			"decryption failed".to_string(),
+		));
+		assert_eq!(passphrase.kind(), NeoErrorKind::Wallet);
 	}
 
 	#[test]

--- a/src/neo_types/string.rs
+++ b/src/neo_types/string.rs
@@ -129,7 +129,7 @@ impl StringExt for String {
 	}
 
 	fn is_valid_hex(&self) -> bool {
-		self.len() % 2 == 0 && self.chars().all(|c| c.is_ascii_hexdigit())
+		self.len().is_multiple_of(2) && self.chars().all(|c| c.is_ascii_hexdigit())
 	}
 
 	fn address_to_scripthash(&self) -> Result<ScriptHash, &'static str> {

--- a/src/neo_x/bridge/bridge_contract.rs
+++ b/src/neo_x/bridge/bridge_contract.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use crate::{
 	neo_builder::{AccountSigner, TransactionBuilder},
 	neo_clients::{JsonRpcProvider, RpcClient},
-	neo_contract::{ContractError, SmartContractTrait},
+	neo_contract::{checked_vm_integer, ContractError, SmartContractTrait},
 	neo_protocol::Account,
 	neo_types::{
 		serde_with_utils::{deserialize_script_hash, serialize_script_hash},
@@ -183,7 +183,7 @@ impl<'a, P: JsonRpcProvider + 'static> NeoXBridgeContract<'a, P> {
 	/// The bridge fee as a u64
 	pub async fn get_fee(&self, token: &ScriptHash) -> Result<u64, ContractError> {
 		let result = self.call_function_returning_int(Self::GET_FEE, vec![token.into()]).await?;
-		Ok(result as u64)
+		checked_vm_integer(result, "bridge fee")
 	}
 
 	/// Gets the bridge cap for a specific token
@@ -197,7 +197,7 @@ impl<'a, P: JsonRpcProvider + 'static> NeoXBridgeContract<'a, P> {
 	/// The bridge cap as a u64
 	pub async fn get_cap(&self, token: &ScriptHash) -> Result<u64, ContractError> {
 		let result = self.call_function_returning_int(Self::GET_CAP, vec![token.into()]).await?;
-		Ok(result as u64)
+		checked_vm_integer(result, "bridge cap")
 	}
 }
 

--- a/src/neo_x/bridge/evm_bridge.rs
+++ b/src/neo_x/bridge/evm_bridge.rs
@@ -8,11 +8,11 @@ use crate::neo_contract::ContractError;
 // sol! binding for the Neo X EVM Bridge Contract.
 // (alloy::sol! is the maintained successor to ethers::contract::abigen!.)
 sol! {
-    #[sol(rpc)]
-    interface NeoXBridgeEVM {
-        function withdraw(address token, uint256 amount, string memory destination) external payable;
-        function getFee(address token) external view returns (uint256);
-    }
+	#[sol(rpc)]
+	interface NeoXBridgeEVM {
+		function withdraw(address token, uint256 amount, string memory destination) external payable;
+		function getFee(address token) external view returns (uint256);
+	}
 }
 
 /// A wrapper around the Neo X bridge contract on the EVM side.
@@ -56,10 +56,7 @@ impl NeoXBridgeContractEVM {
 	}
 
 	/// Gets the required bridge fee for a given token
-	pub async fn get_fee(
-		&self,
-		token: Address,
-	) -> Result<U256, alloy::contract::Error> {
+	pub async fn get_fee(&self, token: Address) -> Result<U256, alloy::contract::Error> {
 		self.contract.getFee(token).call().await
 	}
 }

--- a/src/neo_x/evm/provider.rs
+++ b/src/neo_x/evm/provider.rs
@@ -40,8 +40,9 @@ impl<'a, P: JsonRpcProvider + 'static> NeoXProvider<'a, P> {
 		Self { rpc_url: rpc_url.to_string(), provider, evm_provider }
 	}
 
-	/// Creates a new NeoXProvider instance configured for Anti-MEV
-	/// Uses a protected RPC endpoint that obfuscates transaction ordering.
+	/// Creates a provider using a third-party RPC endpoint marketed as Anti-MEV.
+	///
+	/// This only selects the endpoint; any MEV mitigation is service-dependent and not guaranteed.
 	pub fn new_anti_mev(provider: Option<&'a RpcClient<P>>) -> Self {
 		Self::new(NEO_X_MAINNET_MEV_RPC, provider)
 	}
@@ -100,7 +101,10 @@ impl<'a, P: JsonRpcProvider + 'static> NeoXProvider<'a, P> {
 	}
 
 	/// Gets the native balance for an EVM address via the alloy provider.
-	pub async fn get_balance(&self, address: alloy::primitives::Address) -> Result<AlloyU256, ContractError> {
+	pub async fn get_balance(
+		&self,
+		address: alloy::primitives::Address,
+	) -> Result<AlloyU256, ContractError> {
 		let evm = self.evm_provider.as_ref().ok_or_else(|| {
 			ContractError::ProviderNotSet("EVM provider required for balance query".to_string())
 		})?;

--- a/src/neo_x/evm/transaction.rs
+++ b/src/neo_x/evm/transaction.rs
@@ -64,12 +64,32 @@ impl NeoXTransaction {
 	/// Converts this transaction into an alloy `TransactionRequest`.
 	/// This makes it simple to submit the transaction via an alloy provider.
 	pub fn into_alloy_request(self) -> TransactionRequest {
+		Self::build_alloy_request(
+			self.to,
+			self.data,
+			AlloyU256::from(self.value),
+			self.gas_limit,
+			self.gas_price,
+		)
+	}
+
+	/// Builds an Alloy transaction request with a full-width EVM value.
+	///
+	/// This additive path preserves the legacy [`NeoXTransaction`] serialization and accessors
+	/// while allowing callers to transfer values above [`u64::MAX`].
+	pub fn build_alloy_request(
+		to: Option<H160>,
+		data: Vec<u8>,
+		value: AlloyU256,
+		gas_limit: u64,
+		gas_price: u64,
+	) -> TransactionRequest {
 		TransactionRequest {
-			to: self.to.map(|h| alloy::primitives::TxKind::Call(AlloyAddress::from(h.0))),
-			input: self.data.into(),
-			value: Some(AlloyU256::from(self.value)),
-			gas: Some(self.gas_limit),
-			max_fee_per_gas: Some(self.gas_price as u128),
+			to: to.map(|hash| alloy::primitives::TxKind::Call(AlloyAddress::from(hash.0))),
+			input: data.into(),
+			value: Some(value),
+			gas: Some(gas_limit),
+			max_fee_per_gas: Some(gas_price as u128),
 			..Default::default()
 		}
 	}
@@ -88,11 +108,25 @@ mod tests {
 	#[test]
 	fn test_into_alloy_request() {
 		let tx = NeoXTransaction::new(None, vec![1, 2, 3], 1000, 21000, 1_000_000_000);
+		let legacy_value: u64 = tx.value();
+		let serialized = serde_json::to_value(&tx).unwrap();
+		assert_eq!(legacy_value, 1000);
+		assert_eq!(serialized["value"], serde_json::json!(1000));
+		assert_eq!(serde_json::from_value::<NeoXTransaction>(serialized).unwrap().value(), 1000);
 
 		let req = tx.into_alloy_request();
 		assert!(matches!(req.to, None | Some(alloy::primitives::TxKind::Create)));
 		assert_eq!(req.value, Some(AlloyU256::from(1000)));
 		assert_eq!(req.gas, Some(21000));
 		assert_eq!(req.max_fee_per_gas, Some(1_000_000_000));
+	}
+
+	#[test]
+	fn preserves_values_above_u64() {
+		let value = AlloyU256::from(u64::MAX) + AlloyU256::from(1_u8);
+		let request =
+			NeoXTransaction::build_alloy_request(None, Vec::new(), value, 21_000, 1_000_000_000);
+
+		assert_eq!(request.value, Some(value));
 	}
 }

--- a/src/neo_x/evm/wallet.rs
+++ b/src/neo_x/evm/wallet.rs
@@ -1,13 +1,13 @@
-use alloy::primitives::Address as AlloyAddress;
-use alloy::primitives::U256 as AlloyU256;
-use alloy::providers::{Provider, ProviderBuilder};
-use alloy::rpc::types::eth::TransactionReceipt;
-use alloy::signers::local::{PrivateKeySigner, LocalSignerError};
-use alloy::signers::Signer;
-use std::str::FromStr;
 use crate::neo_clients::JsonRpcProvider;
 use crate::neo_x::evm::provider::NeoXProvider;
 use crate::neo_x::evm::transaction::NeoXTransaction;
+use alloy::primitives::Address as AlloyAddress;
+use alloy::primitives::U256 as AlloyU256;
+use alloy::providers::{Provider, ProviderBuilder};
+use alloy::rpc::types::eth::{TransactionReceipt, TransactionRequest};
+use alloy::signers::local::{LocalSignerError, PrivateKeySigner};
+use alloy::signers::Signer;
+use std::str::FromStr;
 
 /// Neo X EVM Wallet for managing accounts and signing transactions on Neo X.
 /// This wraps an alloy `PrivateKeySigner` to provide seamless integration.
@@ -62,7 +62,21 @@ impl<'a, P: JsonRpcProvider + 'static> NeoXClient<'a, P> {
 	}
 
 	/// Sends a `NeoXTransaction` using the configured wallet and provider
-	pub async fn send_transaction(&self, tx: NeoXTransaction) -> Result<TransactionReceipt, String> {
+	pub async fn send_transaction(
+		&self,
+		tx: NeoXTransaction,
+	) -> Result<TransactionReceipt, String> {
+		self.send_transaction_request(tx.into_alloy_request()).await
+	}
+
+	/// Sends an Alloy transaction request using the configured wallet and provider.
+	///
+	/// Use this method when the request needs EVM values wider than the legacy
+	/// [`NeoXTransaction`] representation supports.
+	pub async fn send_transaction_request(
+		&self,
+		request: TransactionRequest,
+	) -> Result<TransactionReceipt, String> {
 		// Ensure an EVM provider is configured (validates the RPC URL early).
 		let _evm = self.provider.evm_provider().ok_or("No EVM provider configured")?;
 
@@ -79,9 +93,7 @@ impl<'a, P: JsonRpcProvider + 'static> NeoXClient<'a, P> {
 			.map_err(|e: url::ParseError| format!("Invalid Neo X RPC URL: {e}"))?;
 		let client = ProviderBuilder::new().wallet(signer).connect_http(url);
 
-		let req = tx.into_alloy_request();
-
-		let pending_tx = client.send_transaction(req).await.map_err(|e| e.to_string())?;
+		let pending_tx = client.send_transaction(request).await.map_err(|e| e.to_string())?;
 
 		let receipt = pending_tx.get_receipt().await.map_err(|e| e.to_string())?;
 

--- a/src/neo_x/mod.rs
+++ b/src/neo_x/mod.rs
@@ -9,8 +9,9 @@
 //!
 //! - EVM compatibility layer for interacting with Neo X as an Ethereum-compatible chain
 //! - Bridge functionality for transferring tokens between Neo N3 and Neo X
-//! - EVM Wallet and client wrappers powered by `ethers-rs`
-//! - Anti-MEV RPC support
+//! - EVM wallet and client wrappers powered by Alloy
+//! - Optional routing through a third-party Anti-MEV RPC endpoint; mitigation is
+//!   service-dependent and does not guarantee prevention of front-running or sandwich attacks
 //! - Transaction creation and signing for Neo X
 //! - Provider interfaces for connecting to Neo X nodes
 //!
@@ -31,10 +32,10 @@
 //!     let neo_provider = HttpProvider::new("https://mainnet1.neo.org:443")?;
 //!     let neo_client = RpcClient::new(neo_provider);
 //!
-//!     // Initialize the Neo X EVM provider (Standard or Anti-MEV)
+//!     // Initialize the Neo X EVM provider with the third-party protected RPC endpoint
 //!     let neo_x_provider = NeoXProvider::new_anti_mev(Some(&neo_client));
 //!
-//!     // Get the chain ID for Neo X natively via ethers-rs or fallback to N3 node
+//!     // Get the chain ID for Neo X via Alloy or fall back to the N3 node
 //!     let chain_id = neo_x_provider.chain_id().await?;
 //!     println!("Neo X Chain ID: {}", chain_id);
 //!

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -89,7 +89,7 @@ pub mod transaction_simulator;
 /// Cross-chain unified client bridging Neo N3 and Neo X (EVM).
 ///
 /// See [`unified::EcosystemClient`] for the entry point. This is currently
-/// the only ethers-rs-style cross-chain wrapper the SDK ships with.
+/// the SDK's Alloy-backed cross-chain wrapper.
 pub mod unified;
 #[cfg(feature = "ws")]
 pub mod websocket;
@@ -239,10 +239,26 @@ impl Default for SdkConfig {
 ///
 /// Neo N3 NEP-17 balances are returned as raw integers (base units). This type keeps the raw
 /// amount exact and provides safe, deterministic formatting without floating-point rounding.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct DecimalAmount {
 	raw: String,
 	decimals: u8,
+}
+
+impl<'de> Deserialize<'de> for DecimalAmount {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		#[derive(Deserialize)]
+		struct DecimalAmountRepr {
+			raw: String,
+			decimals: u8,
+		}
+
+		let value = DecimalAmountRepr::deserialize(deserializer)?;
+		Self::try_from_raw(value.raw, value.decimals).map_err(serde::de::Error::custom)
+	}
 }
 
 /// Reasons [`DecimalAmount::parse`] can reject a string input.
@@ -283,26 +299,45 @@ impl fmt::Display for DecimalAmountParseError {
 impl std::error::Error for DecimalAmountParseError {}
 
 impl DecimalAmount {
-	/// Create an amount from a raw (base-unit) integer string and a decimal scale.
+	/// Try to create an amount from a raw (base-unit) integer string and a decimal scale.
 	///
-	/// `raw` must be a non-negative base-10 integer. Leading zeros are normalized.
-	pub fn from_raw(raw: impl Into<String>, decimals: u8) -> Self {
+	/// `raw` must be a non-negative base-10 integer. Surrounding whitespace and a leading `+`
+	/// are accepted, and leading zeros are normalized.
+	pub fn try_from_raw(
+		raw: impl Into<String>,
+		decimals: u8,
+	) -> Result<Self, DecimalAmountParseError> {
 		let raw = raw.into();
 		let raw = raw.trim();
-		let raw = raw.trim_start_matches('+');
+		if raw.is_empty() {
+			return Err(DecimalAmountParseError::Empty);
+		}
+		if raw.starts_with('-') {
+			return Err(DecimalAmountParseError::NegativeNotAllowed);
+		}
 
-		let raw = if raw.chars().all(|c| c.is_ascii_digit()) {
-			let raw = raw.trim_start_matches('0');
-			if raw.is_empty() {
-				"0".to_string()
-			} else {
-				raw.to_string()
-			}
-		} else {
-			"0".to_string()
-		};
+		let raw = raw.strip_prefix('+').unwrap_or(raw);
+		if raw.is_empty() {
+			return Err(DecimalAmountParseError::InvalidFormat);
+		}
+		if !raw.chars().all(|c| c.is_ascii_digit()) {
+			return Err(DecimalAmountParseError::InvalidCharacter);
+		}
 
-		Self { raw, decimals }
+		let raw = raw.trim_start_matches('0');
+		let raw = if raw.is_empty() { "0" } else { raw };
+		Ok(Self { raw: raw.to_string(), decimals })
+	}
+
+	/// Create an amount from a raw (base-unit) integer string and a decimal scale.
+	///
+	/// `raw` must be a non-negative base-10 integer. Prefer [`Self::try_from_raw`] when the
+	/// value comes from an RPC response, cache, configuration, or user input. Malformed input
+	/// produces zero here for backward compatibility with this deprecated constructor.
+	#[deprecated(note = "use DecimalAmount::try_from_raw to handle malformed input")]
+	pub fn from_raw(raw: impl Into<String>, decimals: u8) -> Self {
+		Self::try_from_raw(raw, decimals)
+			.unwrap_or_else(|_| Self { raw: "0".to_string(), decimals })
 	}
 
 	/// Parse a human-formatted decimal string into base units with a fixed `decimals` scale.
@@ -356,7 +391,7 @@ impl DecimalAmount {
 		let whole = whole.trim_start_matches('0');
 		let whole = if whole.is_empty() { "0" } else { whole };
 		let raw = format!("{}{}", whole, frac);
-		Ok(Self::from_raw(raw, decimals))
+		Self::try_from_raw(raw, decimals)
 	}
 
 	/// Raw base-unit integer as a base-10 string.
@@ -487,26 +522,66 @@ async fn send_tx_with_retry<'a>(
 	context: &str,
 ) -> Result<crate::neo_protocol::RawTransaction, NeoError> {
 	let attempts = attempts.max(1);
-	let mut last_err: Option<String> = None;
+	let tx_id = tx.tx_id().map_err(|err| NeoError::transaction(context, err))?;
 	for attempt in 1..=attempts {
 		match tx.send_tx().await {
 			Ok(result) => return Ok(result),
 			Err(err) => {
-				if attempt < attempts {
-					tracing::warn!(
-						attempt = attempt,
-						max_attempts = attempts,
-						context = %context,
-						error = %err,
-						"send_tx failed; retrying"
-					);
-					tokio::time::sleep(delay).await;
+				if matches!(
+					&err,
+					crate::neo_builder::TransactionError::ProviderError(error)
+						if error.is_already_known_transaction()
+				) {
+					tracing::debug!(transaction_hash = %tx_id, "transaction already accepted by node");
+					return Ok(crate::neo_protocol::RawTransaction::new(tx_id));
 				}
-				last_err = Some(err.to_string());
+
+				let retryable = matches!(
+					&err,
+					crate::neo_builder::TransactionError::ProviderError(error)
+						if error.is_retryable()
+				);
+				let retry_delay = match &err {
+					crate::neo_builder::TransactionError::ProviderError(error) => {
+						error.retry_after().unwrap_or(delay)
+					},
+					_ => delay,
+				};
+				if !retryable || attempt == attempts {
+					return Err(match err {
+						crate::neo_builder::TransactionError::ProviderError(error)
+							if error.is_transaction_rejection() =>
+						{
+							NeoError::Transaction {
+								message: format!("{}: {}", context, error),
+								tx_hash: Some(format!("{tx_id:#x}")),
+								source: Some(Box::new(error)),
+								recovery: ErrorRecovery::new().suggest(
+									"Review the transaction fees, policy, script, and signatures",
+								),
+							}
+						},
+						crate::neo_builder::TransactionError::ProviderError(error) => {
+							NeoError::provider(context, error)
+						},
+						other => NeoError::transaction(context, other),
+					});
+				}
+
+				tracing::warn!(
+					attempt = attempt,
+					max_attempts = attempts,
+					context = %context,
+					error = %err,
+					retry_delay = ?retry_delay,
+					"send_tx failed; retrying"
+				);
+				tokio::time::sleep(retry_delay).await;
 			},
 		}
 	}
-	Err(NeoError::network(context, last_err.expect("loop ran at least once")))
+
+	unreachable!("the retry loop executes at least once")
 }
 
 impl Neo {
@@ -692,7 +767,8 @@ impl Neo {
 			.first()
 			.ok_or_else(|| invalid_balance_response("GAS", "missing stack item"))?;
 		let gas_raw = parse_balance_stack_item_u64(gas_raw, "GAS")?;
-		let gas = DecimalAmount::from_raw(gas_raw.to_string(), 8); // GAS has 8 decimals
+		let gas = DecimalAmount::try_from_raw(gas_raw.to_string(), 8)
+			.map_err(|err| invalid_balance_response("GAS", err.to_string()))?;
 
 		let nep17 =
 			retry_network("fetch NEP-17 balances", max_attempts, DEFAULT_RETRY_DELAY, || async {
@@ -706,7 +782,9 @@ impl Neo {
 			.filter(|b| b.asset_hash != neo_hash && b.asset_hash != gas_hash)
 			.map(|b| {
 				let decimals = parse_nep17_decimals(b.decimals.as_deref(), &b.asset_hash)?;
-				let amount = DecimalAmount::from_raw(b.amount, decimals);
+				let amount = DecimalAmount::try_from_raw(b.amount, decimals).map_err(|err| {
+					invalid_balance_response(&b.asset_hash.to_hex(), err.to_string())
+				})?;
 
 				Ok(TokenBalance {
 					contract: b.asset_hash,
@@ -1166,7 +1244,10 @@ impl Neo {
 		while start.elapsed() < timeout {
 			match self.client.get_application_log(tx_h256).await {
 				Ok(_) => return Ok(()),
-				Err(_) => tokio::time::sleep(Duration::from_secs(1)).await,
+				Err(err) if err.is_unknown_transaction() || err.is_retryable() => {
+					tokio::time::sleep(Duration::from_secs(1)).await;
+				},
+				Err(err) => return Err(NeoError::provider("poll transaction confirmation", err)),
 			}
 		}
 
@@ -1389,7 +1470,7 @@ impl Transfer {
 		let current_height = client
 			.get_block_count()
 			.await
-			.map_err(|e| NeoError::network("Failed to fetch current block height", e))?;
+			.map_err(|e| NeoError::provider("fetch current block height", e))?;
 
 		let mut tb = TransactionBuilder::with_client(client);
 		tb.extend_script(sb.to_bytes());
@@ -1458,6 +1539,119 @@ fn parse_nep17_decimals(decimals: Option<&str>, asset_hash: &ScriptHash) -> Resu
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+	#[test]
+	fn decimal_amount_rejects_invalid_raw_values() {
+		assert_eq!(
+			DecimalAmount::try_from_raw("not-a-number", 8),
+			Err(DecimalAmountParseError::InvalidCharacter)
+		);
+		assert_eq!(
+			DecimalAmount::try_from_raw("-1", 8),
+			Err(DecimalAmountParseError::NegativeNotAllowed)
+		);
+	}
+
+	#[test]
+	fn decimal_amount_deserialization_validates_raw_value() {
+		let error = serde_json::from_str::<DecimalAmount>(r#"{"raw":"invalid","decimals":8}"#)
+			.expect_err("invalid raw amounts must not enter the SDK through cached JSON");
+		assert!(error.to_string().contains("invalid"));
+	}
+
+	#[test]
+	#[allow(deprecated)]
+	fn deprecated_decimal_amount_constructor_preserves_invalid_input_fallback() {
+		let amount = DecimalAmount::from_raw("not-a-number", 8);
+
+		assert_eq!(amount.raw(), "0");
+		assert_eq!(amount.to_fixed_string(), "0.00000000");
+	}
+
+	async fn transaction_with_broadcast_responses(
+		broadcast_responses: Vec<(&'static str, String)>,
+		attempts: u32,
+	) -> (Result<crate::neo_protocol::RawTransaction, NeoError>, primitive_types::H256) {
+		let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+		let address = listener.local_addr().unwrap();
+		let server = tokio::spawn(async move {
+			let mut responses = broadcast_responses.into_iter();
+			loop {
+				let (mut stream, _) = listener.accept().await.unwrap();
+				let mut request = [0_u8; 16 * 1024];
+				let bytes_read = stream.read(&mut request).await.unwrap();
+				let request = String::from_utf8_lossy(&request[..bytes_read]);
+
+				let (status, body) = if request.contains("getblockcount") {
+					("200 OK", r#"{"jsonrpc":"2.0","id":1,"result":100}"#.to_string())
+				} else {
+					responses.next().expect("unexpected broadcast request")
+				};
+
+				let response = format!(
+					"HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+					body.len()
+				);
+				stream.write_all(response.as_bytes()).await.unwrap();
+				if responses.len() == 0 {
+					break;
+				}
+			}
+		});
+
+		let endpoint = url::Url::parse(&format!("http://{address}")).unwrap();
+		let provider = HttpProvider::new(endpoint).unwrap();
+		let client = RpcClient::new(provider);
+		let mut transaction = crate::neo_builder::Transaction::<HttpProvider> {
+			network: Some(&client),
+			..Default::default()
+		};
+		let expected_hash = transaction.tx_id().unwrap();
+
+		let result = send_tx_with_retry(
+			&mut transaction,
+			attempts,
+			Duration::ZERO,
+			"broadcast test transaction",
+		)
+		.await;
+
+		server.await.unwrap();
+		(result, expected_hash)
+	}
+
+	#[tokio::test]
+	async fn send_retry_accepts_transactions_already_known_by_the_node() {
+		for code in [-501, -503] {
+			let responses = vec![
+				("503 Service Unavailable", "response lost after submission".to_string()),
+				(
+					"200 OK",
+					format!(
+						r#"{{"jsonrpc":"2.0","id":4,"error":{{"code":{code},"message":"already known","data":null}}}}"#
+					),
+				),
+			];
+			let (result, expected_hash) = transaction_with_broadcast_responses(responses, 2).await;
+			assert_eq!(result.unwrap().hash, expected_hash);
+		}
+	}
+
+	#[tokio::test]
+	async fn send_retry_classifies_node_rejection_as_transaction_error() {
+		let response = r#"{"jsonrpc":"2.0","id":2,"error":{"code":-504,"message":"Insufficient network fee","data":null}}"#;
+		let (result, expected_hash) =
+			transaction_with_broadcast_responses(vec![("200 OK", response.to_string())], 1).await;
+
+		match result.unwrap_err() {
+			NeoError::Transaction { tx_hash, recovery, .. } => {
+				assert_eq!(tx_hash.as_deref(), Some(format!("{expected_hash:#x}").as_str()));
+				assert!(!recovery.retryable);
+			},
+			other => panic!("expected transaction rejection, got {other:?}"),
+		}
+	}
 	use crate::neo_types::StackItem;
 
 	#[test]

--- a/src/sdk/retry.rs
+++ b/src/sdk/retry.rs
@@ -3,13 +3,13 @@
 //! This intentionally does not duplicate the lower-level
 //! [`crate::neo_clients::RetryClient`] / [`crate::neo_clients::CircuitBreaker`]
 //! infrastructure — it only wraps an async closure with a bounded retry budget
-//! and uniform [`NeoError::network`] mapping so the call sites in
+//! and provider-aware [`NeoError`] mapping so the call sites in
 //! `sdk/mod.rs` stay readable.
 
 use std::future::Future;
 use std::time::Duration;
 
-use crate::neo_error::unified::NeoError;
+use crate::{neo_clients::ProviderError, neo_error::unified::NeoError};
 
 /// Default base delay between retries used by the high-level SDK.
 pub(crate) const DEFAULT_RETRY_DELAY: Duration = Duration::from_millis(250);
@@ -19,10 +19,9 @@ pub(crate) const DEFAULT_RETRY_DELAY: Duration = Duration::from_millis(250);
 /// `attempts` is the total number of attempts (so `attempts = 1` means *no*
 /// retry — the operation runs exactly once). Failures are logged via
 /// `tracing` at `warn` level on every non-terminal attempt, and the final
-/// error is mapped to [`NeoError::Network`] with `context` woven into the
-/// message so users can see *which* call failed without reading a stack
-/// trace.
-pub(crate) async fn retry_network<T, E, F, Fut>(
+/// error keeps its provider classification with `context` woven into the message. Deterministic
+/// failures return immediately without consuming the retry budget.
+pub(crate) async fn retry_network<T, F, Fut>(
 	context: &str,
 	attempts: u32,
 	delay: Duration,
@@ -30,32 +29,32 @@ pub(crate) async fn retry_network<T, E, F, Fut>(
 ) -> Result<T, NeoError>
 where
 	F: FnMut() -> Fut,
-	Fut: Future<Output = Result<T, E>>,
-	E: std::fmt::Display,
+	Fut: Future<Output = Result<T, ProviderError>>,
 {
 	let attempts = attempts.max(1);
-	let mut last_err: Option<E> = None;
 	for attempt in 1..=attempts {
 		match operation().await {
 			Ok(value) => return Ok(value),
 			Err(err) => {
-				if attempt < attempts {
-					tracing::warn!(
-						attempt = attempt,
-						max_attempts = attempts,
-						context = %context,
-						error = %err,
-						"sdk operation failed; retrying"
-					);
-					tokio::time::sleep(delay).await;
+				if !err.is_retryable() || attempt == attempts {
+					return Err(NeoError::provider(context, err));
 				}
-				last_err = Some(err);
+				let retry_delay = err.retry_after().unwrap_or(delay);
+
+				tracing::warn!(
+					attempt = attempt,
+					max_attempts = attempts,
+					context = %context,
+					error = %err,
+					retry_delay = ?retry_delay,
+					"sdk operation failed; retrying"
+				);
+				tokio::time::sleep(retry_delay).await;
 			},
 		}
 	}
 
-	let err = last_err.expect("retry loop ran at least once");
-	Err(NeoError::network(context, err))
+	unreachable!("the retry loop executes at least once")
 }
 
 #[cfg(test)]
@@ -73,7 +72,7 @@ mod tests {
 				let calls = calls_clone.clone();
 				async move {
 					calls.fetch_add(1, Ordering::SeqCst);
-					Ok::<u32, &'static str>(7)
+					Ok::<u32, ProviderError>(7)
 				}
 			})
 			.await;
@@ -82,7 +81,7 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn maps_final_failure_to_network_error_with_context() {
+	async fn maps_final_failure_with_context() {
 		let calls = Arc::new(AtomicUsize::new(0));
 		let calls_clone = calls.clone();
 		let result: Result<(), NeoError> =
@@ -90,7 +89,11 @@ mod tests {
 				let calls = calls_clone.clone();
 				async move {
 					calls.fetch_add(1, Ordering::SeqCst);
-					Err::<(), _>("upstream 503")
+					Err::<(), _>(ProviderError::JsonRpcError(crate::neo_clients::JsonRpcError {
+						code: 429,
+						message: "too many requests".to_string(),
+						data: None,
+					}))
 				}
 			})
 			.await;
@@ -98,6 +101,54 @@ mod tests {
 		assert_eq!(calls.load(Ordering::SeqCst), 2);
 		assert!(err.is_retryable());
 		assert!(err.message().contains("fetch block"));
-		assert!(err.message().contains("upstream 503"));
+		assert!(err.message().contains("too many requests"));
+	}
+
+	#[tokio::test]
+	async fn stops_after_a_deterministic_provider_error() {
+		let calls = Arc::new(AtomicUsize::new(0));
+		let calls_clone = calls.clone();
+		let result: Result<(), NeoError> =
+			retry_network("validate address", 3, Duration::from_millis(1), move || {
+				let calls = calls_clone.clone();
+				async move {
+					calls.fetch_add(1, Ordering::SeqCst);
+					Err::<(), _>(ProviderError::InvalidAddress)
+				}
+			})
+			.await;
+
+		assert_eq!(calls.load(Ordering::SeqCst), 1);
+		assert!(!result.unwrap_err().is_retryable());
+	}
+
+	#[tokio::test]
+	async fn honors_provider_retry_after_hint() {
+		let calls = Arc::new(AtomicUsize::new(0));
+		let calls_clone = calls.clone();
+
+		let result = tokio::time::timeout(
+			Duration::from_millis(100),
+			retry_network("rate limited", 2, Duration::from_millis(1), move || {
+				let calls = calls_clone.clone();
+				async move {
+					if calls.fetch_add(1, Ordering::SeqCst) == 0 {
+						Err(ProviderError::JsonRpcError(crate::neo_clients::JsonRpcError {
+							code: 429,
+							message: "too many requests".to_string(),
+							data: Some(serde_json::json!({
+								"rate": { "backoff_seconds": 2 }
+							})),
+						}))
+					} else {
+						Ok(7_u32)
+					}
+				}
+			}),
+		)
+		.await;
+
+		assert!(result.is_err(), "the provider's two-second backoff must be honored");
+		assert_eq!(calls.load(Ordering::SeqCst), 1);
 	}
 }

--- a/src/sdk/unified.rs
+++ b/src/sdk/unified.rs
@@ -50,7 +50,7 @@ const NEOX_BRIDGE_GAS_LIMIT: u64 = 200_000;
 const GAS_DECIMALS: u8 = 8;
 
 /// Unified Ecosystem Client that pairs a Provider with a Wallet for either Neo N3 or Neo X.
-/// Designed with an ethers-rs style interface for cross-chain consistency.
+/// Uses the SDK's native Neo N3 APIs and Alloy-backed Neo X APIs behind one interface.
 pub enum EcosystemClient<'a> {
 	/// N3 Network Client
 	N3 {
@@ -78,8 +78,10 @@ impl<'a> EcosystemClient<'a> {
 		Self::NeoX { client }
 	}
 
-	/// Connects to Neo X using an Anti-MEV configured endpoint.
-	/// This guards transactions against mempool sandwich attacks and front-running.
+	/// Connects to Neo X through the configured third-party protected RPC endpoint.
+	///
+	/// Protection characteristics are determined by the endpoint operator; routing through this
+	/// endpoint does not guarantee prevention of front-running or sandwich attacks.
 	pub fn new_neox_anti_mev(wallet: NeoXWallet) -> Self {
 		let provider = NeoXProvider::new_anti_mev(None);
 		let client = NeoXClient::new(wallet, provider);
@@ -95,10 +97,7 @@ impl<'a> EcosystemClient<'a> {
 					.ok_or_else(no_default_account_error)?
 					.address_or_scripthash
 					.address();
-				let balance = provider
-					.get_balance(&address)
-					.await
-					.map_err(|e| NeoError::network("Neo X balance lookup", e))?;
+				let balance = provider.get_balance(&address).await?;
 				Ok(balance.gas.to_string())
 			},
 			Self::NeoX { client } => {
@@ -120,10 +119,7 @@ impl<'a> EcosystemClient<'a> {
 					.map_err(|e| amount_validation_error(amount, e))?;
 				let amount_u64 =
 					parsed.raw().parse::<u64>().map_err(|e| amount_validation_error(amount, e))?;
-				let tx_hash = provider
-					.transfer(wallet, to, amount_u64, Token::GAS)
-					.await
-					.map_err(|e| NeoError::transaction("N3 transfer failed", e))?;
+				let tx_hash = provider.transfer(wallet, to, amount_u64, Token::GAS).await?;
 				Ok(tx_hash)
 			},
 			Self::NeoX { client } => {
@@ -133,15 +129,15 @@ impl<'a> EcosystemClient<'a> {
 				let value =
 					U256::from_str(amount).map_err(|e| amount_validation_error(amount, e))?;
 
-				let tx = NeoXTransaction::new(
+				let request = NeoXTransaction::build_alloy_request(
 					Some(to_addr),
 					vec![],
-					value.to::<u64>(),
+					value,
 					NEOX_TRANSFER_GAS_LIMIT,
 					NEOX_GAS_PRICE_WEI,
 				);
 				let receipt = client
-					.send_transaction(tx)
+					.send_transaction_request(request)
 					.await
 					.map_err(|e| NeoError::transaction("Neo X transfer failed", e))?;
 				Ok(format!("{:?}", receipt.transaction_hash))

--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -1,7 +1,7 @@
 neorust-team:
   name: NeoRust Team
   title: Core Development Team
-  url: https://github.com/R3E-Network/NeoRust
+  url: https://github.com/r3e-network/neo-rust-sdk
   image_url: https://github.com/R3E-Network.png
   email: team@neorust.org
 

--- a/website/cli/configuration.md
+++ b/website/cli/configuration.md
@@ -15,7 +15,7 @@ neorust config init
 
 # Verify installation
 neorust --version
-# Output: neorust 2.0.0
+# Output: neo-cli 2.1.0
 ```
 
 ### First-time Configuration
@@ -52,7 +52,7 @@ export NEORUST_CONFIG_PATH="/custom/path/config.toml"
 ### Structure
 
 ```toml
-# NeoRust CLI Configuration v2.0.0
+# NeoRust CLI Configuration v2.1.0
 
 [general]
 # Default network for operations

--- a/website/cli/intro.md
+++ b/website/cli/intro.md
@@ -25,7 +25,7 @@ cargo install neo3-cli
 
 # Verify installation
 neorust --version
-# Output: neorust 2.0.1
+# Output: neo-cli 2.1.0
 
 # Initialize configuration
 neorust config init
@@ -430,7 +430,7 @@ neorust config show
 - **[Examples](../examples)**: Real-world usage examples
 
 ### Community Support
-- **GitHub Issues**: [Report bugs and request features](https://github.com/R3E-Network/NeoRust/issues)
+- **GitHub Issues**: [Report bugs and request features](https://github.com/r3e-network/neo-rust-sdk/issues)
 - **Discord Chat**: [Join our community](https://discord.gg/neo-rust)
 - **Forum**: [Ask questions and share knowledge](https://forum.neorust.org)
 
@@ -441,4 +441,4 @@ neorust config show
 
 ---
 
-**Ready to master the command line?** Start with the [Commands Reference](./commands) and explore the full power of NeoRust CLI! ⚡🦀 
+**Ready to master the command line?** Start with the [Commands Reference](./commands) and explore the full power of NeoRust CLI! ⚡🦀

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -4,7 +4,7 @@ Get started with NeoRust SDK by installing it in your development environment.
 
 ## System Requirements
 
-- **Rust**: Version 1.70 or later
+- **Rust**: Version 1.91 or later
 - **Cargo**: Rust's package manager (included with Rust)
 - **Operating System**: Windows, macOS, or Linux
 
@@ -29,7 +29,7 @@ Add NeoRust to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-neo3 = "2.0.1"
+neo3 = "2.1.0"
 tokio = { version = "1.0", features = ["full"] }
 ```
 
@@ -39,7 +39,7 @@ NeoRust provides several optional features:
 
 ```toml
 [dependencies]
-neo3 = { version = "2.0.1", features = ["futures", "ledger"] }
+neo3 = { version = "2.1.0", features = ["futures", "ledger"] }
 ```
 
 ### Available Features
@@ -62,7 +62,7 @@ Create a simple test to verify everything works:
 use neo3::prelude::*;
 
 fn main() {
-    println!("NeoRust SDK v2.0.1 is ready!");
+    println!("NeoRust SDK v2.1.0 is ready!");
     
     // Create a simple account
     let account = Account::create().expect("Failed to create account");
@@ -78,7 +78,7 @@ cargo run
 
 You should see output like:
 ```
-NeoRust SDK v2.0.1 is ready!
+NeoRust SDK v2.1.0 is ready!
 Generated address: NXXXXxxxXXXxxxXXXxxxXXXxxxXXXxxx
 ```
 
@@ -116,4 +116,4 @@ sudo yum groupinstall "Development Tools"
 ## Next Steps
 
 - [Quick Start Guide](./quick-start.md) - Your first Neo application
-- [Examples](/examples) - Practical code examples 
+- [Examples](/examples) - Practical code examples

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -4,7 +4,7 @@ Get up and running with NeoRust SDK in just a few minutes. This guide will walk 
 
 ## Prerequisites
 
-- Rust 1.70+ installed
+- Rust 1.91+ installed
 - NeoRust SDK added to your project
 
 If you haven't installed NeoRust yet, see the [Installation Guide](./installation.md).
@@ -277,7 +277,7 @@ impl NeoService {
 1. **📚 [Explore Documentation](../intro.md)** - Learn about advanced features
 2. **🔍 [View Examples](/examples)** - See more practical code examples  
 3. **🛠️ [Try the CLI Tool](/cli/intro)** - Use command-line tools for development
-4. **🤝 [Join Community](https://github.com/R3E-Network/NeoRust/discussions)** - Get help and share projects
+4. **🤝 [Join Community](https://github.com/r3e-network/neo-rust-sdk/discussions)** - Get help and share projects
 
 ### Useful Resources
 

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -2,7 +2,7 @@
 
 <div className="hero hero--primary">
   <div className="container">
-    <h1 className="hero__title">🚀 NeoRust v2.0.1</h1>
+    <h1 className="hero__title">🚀 NeoRust v2.1.0</h1>
     <p className="hero__subtitle">
       Production-Ready Neo N3 Development Suite with 207+ Passing Doc Tests
     </p>
@@ -125,7 +125,7 @@ cargo build --release
 
 ```toml
 [dependencies]
-neo3 = "2.0.1"
+neo3 = "2.1.0"
 ```
 
 ```rust
@@ -186,20 +186,20 @@ This documentation is organized into several sections:
 ## 🌐 Community & Support
 
 ### 📞 **Getting Help**
-- **GitHub Issues**: [Report bugs and request features](https://github.com/R3E-Network/NeoRust/issues)
-- **Discussions**: [Community discussions and Q&A](https://github.com/R3E-Network/NeoRust/discussions)
+- **GitHub Issues**: [Report bugs and request features](https://github.com/r3e-network/neo-rust-sdk/issues)
+- **Discussions**: [Community discussions and Q&A](https://github.com/r3e-network/neo-rust-sdk/discussions)
 - **Documentation**: [Comprehensive guides and API docs](https://neorust.netlify.app)
 
 ### 🤝 **Contributing**
-- **[Contributing Guide](https://github.com/R3E-Network/NeoRust/blob/master/CONTRIBUTING.md)**: How to contribute to NeoRust
-- **[System Architecture](https://github.com/R3E-Network/NeoRust/blob/master/SYSTEM_ARCHITECTURE_DESIGN.md)**: Core architecture and components
-- **[API Guidelines](https://github.com/R3E-Network/NeoRust/blob/master/API_GUIDELINES.md)**: API design standards and guidance
+- **[Contributing Guide](https://github.com/r3e-network/neo-rust-sdk/blob/master/CONTRIBUTING.md)**: How to contribute to NeoRust
+- **[System Architecture](https://github.com/r3e-network/neo-rust-sdk/blob/master/SYSTEM_ARCHITECTURE_DESIGN.md)**: Core architecture and components
+- **[API Guidelines](https://github.com/r3e-network/neo-rust-sdk/blob/master/API_GUIDELINES.md)**: API design standards and guidance
 
 ### 🔗 **Links**
 - **Website**: [https://neorust.netlify.app](https://neorust.netlify.app)
 - **Crate**: [https://crates.io/crates/neo3](https://crates.io/crates/neo3)
 - **API Docs**: [https://docs.rs/neo3](https://docs.rs/neo3)
-- **GitHub**: [https://github.com/R3E-Network/NeoRust](https://github.com/R3E-Network/NeoRust)
+- **GitHub**: [https://github.com/r3e-network/neo-rust-sdk](https://github.com/r3e-network/neo-rust-sdk)
 
 ---
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -7,7 +7,7 @@ const darkCodeTheme = themes.dracula;
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'NeoRust v2.0.1',
+  title: 'NeoRust v2.1.0',
   tagline: 'Production-ready Neo N3 blockchain development toolkit built in Rust',
   favicon: 'img/favicon.png',
 
@@ -23,7 +23,11 @@ const config = {
   projectName: 'NeoRust', // Usually your repo name.
 
   onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
+  },
 
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want
@@ -42,13 +46,13 @@ const config = {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: 'https://github.com/R3E-Network/NeoRust/tree/master/website/',
+          editUrl: 'https://github.com/r3e-network/neo-rust-sdk/tree/master/website/',
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,
           includeCurrentVersion: true,
           versions: {
             current: {
-              label: 'v2.0.1',
+              label: 'v2.1.0',
               path: '',
             },
           },
@@ -60,7 +64,7 @@ const config = {
           postsPerPage: 'ALL',
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: 'https://github.com/R3E-Network/NeoRust/tree/master/website/',
+          editUrl: 'https://github.com/r3e-network/neo-rust-sdk/tree/master/website/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
@@ -82,7 +86,7 @@ const config = {
       image: 'img/neorust-social-card.jpg',
       metadata: [
         { name: 'keywords', content: 'neo, blockchain, rust, sdk, neo3, cryptocurrency, smart-contracts, defi' },
-        { name: 'description', content: 'NeoRust v2.0.1 - A production-ready Rust SDK for Neo N3 blockchain development. Build high-performance dApps with type-safe, modern Rust. Optimized and production-ready.' },
+        { name: 'description', content: 'NeoRust v2.1.0 - A production-ready Rust SDK for Neo N3 blockchain development. Build high-performance dApps with type-safe, modern Rust. Optimized and production-ready.' },
         { property: 'og:image', content: 'https://neorust.netlify.app/img/neorust-social-card.jpg' },
         { property: 'og:type', content: 'website' },
         { name: 'twitter:card', content: 'summary_large_image' },
@@ -147,7 +151,7 @@ const config = {
               },
               {
                 label: '⭐ GitHub Repository',
-                href: 'https://github.com/R3E-Network/NeoRust',
+                href: 'https://github.com/r3e-network/neo-rust-sdk',
                 className: 'dropdown-divider-top',
               },
             ],
@@ -196,7 +200,7 @@ const config = {
             items: [
               {
                 label: 'GitHub',
-                href: 'https://github.com/R3E-Network/NeoRust',
+                href: 'https://github.com/r3e-network/neo-rust-sdk',
               },
               {
                 label: 'Discord',
@@ -243,7 +247,7 @@ const config = {
         copyright: `
           <div style="margin-top: 16px; padding-top: 16px; border-top: 1px solid #333;">
             <p>Copyright © ${new Date().getFullYear()} R3E Network. Built with ❤️ and Docusaurus.</p>
-            <p>NeoRust v2.0.1 - Production-Ready Neo N3 Development Suite - Optimized and Enhanced</p>
+            <p>NeoRust v2.1.0 - Production-Ready Neo N3 Development Suite - Optimized and Enhanced</p>
           </div>
         `,
       },
@@ -269,9 +273,9 @@ const config = {
         respectPrefersColorScheme: true,
       },
       announcementBar: {
-        id: 'v2.0.1-release',
+        id: 'v2.1.0-release',
         content:
-          '🎉 <strong>NeoRust v2.0.1</strong> is now available! AWS-SDK-style error metadata, unified high-level API, and production hardening. <a target="_blank" rel="noopener noreferrer" href="https://github.com/R3E-Network/NeoRust/releases/tag/v2.0.1">See what\'s new</a>',
+          '🎉 <strong>NeoRust v2.1.0</strong> is now available! Checked amounts, provider-aware retries, secret-safe errors, and stronger release validation. <a target="_blank" rel="noopener noreferrer" href="https://github.com/r3e-network/neo-rust-sdk/releases/tag/v2.1.0">See what\'s new</a>',
         backgroundColor: '#059669',
         textColor: '#ffffff',
         isCloseable: true,
@@ -312,7 +316,7 @@ const config = {
         path: 'sdk',
         routeBasePath: 'sdk',
         sidebarPath: require.resolve('./sidebars-sdk.js'),
-        editUrl: 'https://github.com/R3E-Network/NeoRust/tree/master/website/',
+        editUrl: 'https://github.com/r3e-network/neo-rust-sdk/tree/master/website/',
         showLastUpdateAuthor: true,
         showLastUpdateTime: true,
       },
@@ -324,7 +328,7 @@ const config = {
         path: 'cli',
         routeBasePath: 'cli',
         sidebarPath: require.resolve('./sidebars-cli.js'),
-        editUrl: 'https://github.com/R3E-Network/NeoRust/tree/master/website/',
+        editUrl: 'https://github.com/r3e-network/neo-rust-sdk/tree/master/website/',
         showLastUpdateAuthor: true,
         showLastUpdateTime: true,
       },

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neorust-website",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neorust-website",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "@docusaurus/core": "^3.10.1",
         "@docusaurus/plugin-content-blog": "^3.10.1",
@@ -9780,9 +9780,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -10304,9 +10304,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",

--- a/website/package.json
+++ b/website/package.json
@@ -1,8 +1,8 @@
 {
   "name": "neorust-website",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "private": true,
-  "description": "Official website and documentation for NeoRust v2.0.1 - A comprehensive Rust SDK for Neo N3 blockchain development",
+  "description": "Official website and documentation for NeoRust v2.1.0 - A comprehensive Rust SDK for Neo N3 blockchain development",
   "keywords": [
     "neo",
     "blockchain",

--- a/website/sdk/api-reference.md
+++ b/website/sdk/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Complete API documentation for NeoRust SDK v2.0.0.
+Complete API documentation for NeoRust SDK v2.1.0.
 
 ## Full Documentation
 

--- a/website/sdk/installation.md
+++ b/website/sdk/installation.md
@@ -1,10 +1,10 @@
 # Installation
 
-Get started with NeoRust SDK v2.0.1 by installing it in your Rust project.
+Get started with NeoRust SDK v2.1.0 by installing it in your Rust project.
 
 ## Prerequisites
 
-- Rust 1.70 or later
+- Rust 1.91 or later
 - Cargo package manager
 
 ## Adding to Your Project
@@ -13,21 +13,21 @@ Add NeoRust to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-neo3 = "2.0.1"
+neo3 = "2.1.0"
 ```
 
 For specific features, use:
 
 ```toml
 [dependencies]
-neo3 = { version = "2.0.1", features = ["futures", "ledger"] }
+neo3 = { version = "2.1.0", features = ["futures", "ledger"] }
 ```
 
 ## Available Features
 
 - `futures` - Async/await support (recommended)
 - `ledger` - Hardware wallet support
-- `websocket` - WebSocket client support
+- `ws` - WebSocket client support
 
 ## Verification
 
@@ -37,11 +37,11 @@ Verify your installation:
 use neo3::prelude::*;
 
 fn main() {
-    println!("NeoRust SDK v2.0.1 is ready!");
+    println!("NeoRust SDK v2.1.0 is ready!");
 }
 ```
 
 ## Next Steps
 
 - [Quick Start Guide](./quick-start.md)
-- [Examples](./examples.md) 
+- [Examples](./examples.md)

--- a/website/sdk/intro.md
+++ b/website/sdk/intro.md
@@ -34,7 +34,7 @@ Add NeoRust to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-neo3 = "2.0.1"
+neo3 = "2.1.0"
 ```
 
 ### Basic Usage
@@ -69,7 +69,7 @@ Customize your installation with feature flags:
 
 ```toml
 [dependencies]
-neo3 = { version = "2.0.1", features = ["futures", "ledger"] }
+neo3 = { version = "2.1.0", features = ["futures", "ledger"] }
 ```
 
 **Available Features:**
@@ -691,8 +691,8 @@ async fn enterprise_asset_management() -> Result<(), Box<dyn std::error::Error>>
 - **[Quick Start](./quick-start)**: Get up and running in 5 minutes
 - **[Examples](./examples)**: Real-world usage examples
 - **[API Reference](https://docs.rs/neo3)**: Complete API documentation
-- **[System Architecture](https://github.com/R3E-Network/NeoRust/blob/master/SYSTEM_ARCHITECTURE_DESIGN.md)**: Core architecture and components
-- **[Security Audit](https://github.com/R3E-Network/NeoRust/blob/master/docs/SECURITY_AUDIT.md)**: Security review and best practices
+- **[System Architecture](https://github.com/r3e-network/neo-rust-sdk/blob/master/SYSTEM_ARCHITECTURE_DESIGN.md)**: Core architecture and components
+- **[Security Audit](https://github.com/r3e-network/neo-rust-sdk/blob/master/docs/SECURITY_AUDIT.md)**: Security review and best practices
 
 ---
 

--- a/website/sdk/troubleshooting.md
+++ b/website/sdk/troubleshooting.md
@@ -4,7 +4,7 @@ Common issues and solutions for NeoRust SDK.
 
 ## Installation Issues
 
-- Ensure Rust 1.70+ is installed
+- Ensure Rust 1.91+ is installed
 - Check Cargo.toml syntax
 
 ## Runtime Issues

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,5 +1,5 @@
 /**
- * NeoRust Documentation Sidebar Configuration v2.0.0
+ * NeoRust Documentation Sidebar Configuration v2.1.0
  * Creating a simplified navigation structure for the documentation
  * @type {import('@docusaurus/plugin-content-docs').SidebarsConfig}
  */
@@ -34,4 +34,4 @@ const sidebars = {
   ],
 };
 
-module.exports = sidebars; 
+module.exports = sidebars;

--- a/website/src/__tests__/Footer.test.tsx
+++ b/website/src/__tests__/Footer.test.tsx
@@ -77,7 +77,7 @@ describe('Footer Component', () => {
     // Check for GitHub link
     const githubLink = screen.getByLabelText('GitHub Repository');
     expect(githubLink).toBeInTheDocument();
-    expect(githubLink).toHaveAttribute('href', 'https://github.com/R3E-Network/NeoRust');
+    expect(githubLink).toHaveAttribute('href', 'https://github.com/r3e-network/neo-rust-sdk');
     
     // Check for Twitter link
     const twitterLink = screen.getByLabelText('Neo Twitter');

--- a/website/src/pages/examples.tsx
+++ b/website/src/pages/examples.tsx
@@ -542,7 +542,7 @@ export default function Examples(): JSX.Element {
                     🦀 Explore SDK
                   </Link>
                   <a 
-                    href="https://github.com/R3E-Network/NeoRust" 
+                    href="https://github.com/r3e-network/neo-rust-sdk"
                     className={clsx('btn btn-secondary', styles.ctaButton)}
                     target="_blank" 
                     rel="noopener noreferrer"
@@ -585,7 +585,7 @@ export default function Examples(): JSX.Element {
                   <p className={styles.resourceDescription}>
                     Join our community for help, discussions, and contributions.
                   </p>
-                  <a href="https://github.com/R3E-Network/NeoRust/discussions" className={styles.resourceLink}>
+                  <a href="https://github.com/r3e-network/neo-rust-sdk/discussions" className={styles.resourceLink}>
                     Join Discussion →
                   </a>
                 </div>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -306,7 +306,7 @@ export default function Home(): JSX.Element {
               </Link>
               <Link
                 className={clsx('btn btn-secondary', styles.heroButton)}
-                href="https://github.com/R3E-Network/NeoRust">
+                href="https://github.com/r3e-network/neo-rust-sdk">
                 <span className={styles.githubIcon}>⭐</span>
                 View on GitHub
               </Link>


### PR DESCRIPTION
## Summary

- harden numeric conversion, provider errors, retry/backoff, transaction rebroadcasts, and secret redaction while preserving 2.x entry points
- add checked DecimalAmount construction, provider-aware NeoError mapping, and full-width Alloy transaction requests
- raise the MSRV to Rust 1.91 and enforce it in CI
- synchronize crate, CLI, website, installation, and changelog metadata for 2.1.0
- make tagged publication fail closed and explicitly restrict crates.io publishing to neo3
- allow cold Windows validation and release artifact builds up to 30 minutes
- map existing publisher secrets to Cargo's documented crates.io authentication variable
- patch OpenSSL, cmov, http-proxy-middleware, and js-yaml versions flagged by GitHub/npm security alerts

## Compatibility

- Existing 2.x methods remain available; DecimalAmount::from_raw is deprecated in favor of try_from_raw.
- Error Display/Debug output now omits provider data and secret-bearing URL components.
- Rust 1.91 is now required. Consumers pinned to Rust 1.83-1.90 must upgrade their toolchain before selecting 2.1.0.

## Verification

- cargo fmt --all -- --check
- strict Clippy for workspace/all features/all targets
- strict Clippy for workspace/no default features/all targets
- Rust 1.91 all-feature library check
- cargo test --workspace --locked
- warnings-as-errors rustdoc
- cargo audit and cargo deny
- npm ci, npm audit: 0 findings, Docusaurus production build
- actionlint for build and release workflows
- clean-tree cargo publish dry run: 279 files, 3.3 MiB unpacked, 1.6 MiB compressed

## Security Notes

- The branch updates openssl to 0.10.81, openssl-sys to 0.9.117, and cmov to 0.5.4. Current default-branch Dependabot alerts will remain visible until merge.
- RUSTSEC-2023-0071 remains explicitly ignored because jsonwebtoken enables RSA transitively while the SDK JWT surface exposes HS256 only.

## Residual Validation

- GitHub-hosted Linux/macOS/Windows builds run on this PR and the release workflow.
- Live Neo broadcasts, physical Ledger/YubiHSM devices, SGX runtime, crates.io credentials, and docs.rs publication require their release environments.