### PR TITLE
Harden the 2.1.0 publication source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,6 @@ on:
   push:
     tags:
       - "v*.*.*"
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Version to release (e.g., v0.5.0)"
-        required: true
-        type: string
 
 # Cancel in-progress runs when a new run is triggered
 concurrency:
@@ -33,19 +27,42 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Determine version
+      - name: Validate release tag
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
-          else
-            VERSION="${GITHUB_REF#refs/tags/}"
+          if [ "$GITHUB_EVENT_NAME" != "push" ] || [ "$GITHUB_REF_TYPE" != "tag" ]; then
+            echo "Error: releases must be triggered by a pushed version tag"
+            exit 1
           fi
+
+          VERSION="$GITHUB_REF_NAME"
           if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
             echo "Error: release version must be valid v-prefixed SemVer"
             exit 1
           fi
+
+          if ! git cat-file -e "refs/tags/${VERSION}^{tag}" 2>/dev/null; then
+            echo "Error: ${VERSION} must be an annotated tag"
+            exit 1
+          fi
+
+          TAG_COMMIT="$(git rev-parse "refs/tags/${VERSION}^{commit}")"
+          CHECKOUT_COMMIT="$(git rev-parse HEAD)"
+          EVENT_COMMIT="$(git rev-parse "${GITHUB_SHA}^{commit}")"
+          if [ "$TAG_COMMIT" != "$CHECKOUT_COMMIT" ] || [ "$TAG_COMMIT" != "$EVENT_COMMIT" ]; then
+            echo "Error: release tag, workflow event, and checkout do not resolve to the same commit"
+            exit 1
+          fi
+
+          git fetch --no-tags origin master:refs/remotes/origin/master
+          if ! git merge-base --is-ancestor "$TAG_COMMIT" refs/remotes/origin/master; then
+            echo "Error: release tag commit must be reachable from origin/master"
+            exit 1
+          fi
+
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Version: ${VERSION}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,14 +276,45 @@ jobs:
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
           VERSION_NUM="${VERSION#v}"
+          RESPONSE_FILE="${RUNNER_TEMP}/neo3-${VERSION_NUM}.json"
 
-          if cargo search neo3 --limit 1 | grep -q "^neo3 = \"${VERSION_NUM}\""; then
-            echo "published=true" >> "$GITHUB_OUTPUT"
-            echo "neo3 ${VERSION_NUM} is already published on crates.io."
-          else
-            echo "published=false" >> "$GITHUB_OUTPUT"
-            echo "neo3 ${VERSION_NUM} is not published on crates.io."
-          fi
+          STATUS="$(
+            curl --silent --show-error --location \
+              --user-agent "neo-rust-sdk-release/${VERSION_NUM}" \
+              --header "Accept: application/json" \
+              --connect-timeout 15 \
+              --max-time 60 \
+              --retry 3 \
+              --retry-all-errors \
+              --retry-delay 2 \
+              --output "$RESPONSE_FILE" \
+              --write-out "%{http_code}" \
+              "https://crates.io/api/v1/crates/neo3/${VERSION_NUM}"
+          )" || {
+            echo "Error: unable to determine whether neo3 ${VERSION_NUM} is published."
+            exit 1
+          }
+
+          case "$STATUS" in
+            200)
+              if ! jq -e --arg version "$VERSION_NUM" '.version.num == $version' "$RESPONSE_FILE" > /dev/null; then
+                echo "Error: crates.io returned unexpected metadata for neo3 ${VERSION_NUM}."
+                cat "$RESPONSE_FILE"
+                exit 1
+              fi
+              echo "published=true" >> "$GITHUB_OUTPUT"
+              echo "neo3 ${VERSION_NUM} is already published on crates.io."
+              ;;
+            404)
+              echo "published=false" >> "$GITHUB_OUTPUT"
+              echo "neo3 ${VERSION_NUM} is not published on crates.io."
+              ;;
+            *)
+              echo "Error: Unexpected crates.io response ${STATUS}; refusing to publish blindly."
+              cat "$RESPONSE_FILE"
+              exit 1
+              ;;
+          esac
 
       - name: Verify package
         if: steps.crates.outputs.published != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,9 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      checks: write
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,10 @@ and release automation fails closed before publishing incomplete releases.
 
 - **Retries follow provider intent:** deterministic failures return immediately;
   transient failures use capped exponential backoff, honor bounded
-  `Retry-After` guidance, and release queue capacity correctly after completion
-  or cancellation.
+  `Retry-After` guidance from JSON-RPC error envelopes, and release queue
+  capacity correctly after completion or cancellation. Plain HTTP 429 responses
+  retain rate-limit classification and use configured backoff for 2.x error
+  compatibility.
 - **Transaction rebroadcasts are outcome-aware:** an already-known transaction
   is treated as accepted, deterministic node rejections become transaction
   errors with the transaction hash, and only transient provider failures are
@@ -50,9 +52,10 @@ and release automation fails closed before publishing incomplete releases.
   bridge, and transaction paths preserve legacy accessors while adding checked
   conversions and full-width request APIs.
 - **Release publication is fail-closed:** tagged releases validate package and
-  changelog versions, run formatting, Clippy, tests, rustdoc, audit, and
-  supply-chain policy checks, and require crates.io credentials before creating
-  the GitHub release.
+  changelog versions, require an annotated tag reachable from `master`, run
+  formatting, Clippy, tests, rustdoc, audit, and supply-chain policy checks,
+  distinguish an absent crate from registry failures, and require crates.io
+  credentials before creating the GitHub release.
 
 ### Fixed
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# NeoRust v2.0.0 - Complete Neo N3 Development Suite
+# NeoRust v2.1.0 - Complete Neo N3 Development Suite
 
 <div align="center">
   <h1>🚀 NeoRust - Production-Ready Neo N3 SDK</h1>

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -143,10 +143,10 @@ The release workflow automatically:
 ### Build & Test (`build-test.yml`)
 Runs on pushes and pull requests:
 - Multi-platform build/test (Linux, Windows, macOS)
-- `cargo fmt` / `cargo clippy` (best-effort; see workflow settings)
+- `cargo fmt` / strict `cargo clippy`
 - `cargo build` / `cargo test` (no-default-features)
 - `cargo doc` build
-- Security audit (`cargo audit`, best-effort)
+- Security audit (RustSec advisories fail; configured informational warnings are reported)
 - Optional code coverage (main/master only)
 
 ### Release Automation (`release.yml`)
@@ -167,8 +167,8 @@ If/when the SDK is split into multiple crates, update this document and `release
 See `WORKSPACE_REORGANIZATION.md` for the tracked plan.
 
 ### Version Synchronization
-The release tag and crates.io publish target the `neo3` crate version. Workspace applications may use
-their own versions, but should depend on a compatible `neo3` version.
+The release tag, `neo3` crate, bundled `neo-cli` artifact, and CLI dependency requirement use the same
+version. `neo-cli` remains explicitly non-publishable and is distributed only through release artifacts.
 
 ## 🔍 Quality Gates
 


### PR DESCRIPTION
## Summary

- remove the publish-capable manual-dispatch path from the release workflow
- require releases to originate from pushed, annotated SemVer tags reachable from `master`
- prove the tag, GitHub event, and checked-out commit resolve identically
- grant the RustSec verifier its documented, job-scoped Checks API permission
- query the exact crates.io version endpoint and abort on ambiguous registry responses
- align release documentation and notes with the enforced 2.1.0 contract

## Why

Crates.io versions are immutable. The workflow must prove reviewed tag provenance, preserve a working security gate, and distinguish an absent version from registry or network failure before it attempts publication.

## Verification

- failing then passing release-trigger, permission, and registry-probe assertions
- `actionlint .github/workflows/release.yml`
- annotated temporary tag accepted; lightweight tag rejected
- tag commit ancestry against `origin/master`
- live crates.io probe: `neo3 2.0.1` returned matching `200`; `2.1.0` returned `404`
- exact Linux release artifact build; binary reports `neo-cli 2.1.0`
- `cargo fmt --all -- --check`
- `git diff --check`
