### PR TITLE
v2.1.0 fix: make release verification toolchain-explicit

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,10 +20,11 @@ jobs:
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4
-    - name: Setup Rust 1.91
-      uses: dtolnay/rust-toolchain@1.91
+    - name: Setup Rust 1.91.0
+      id: msrv
+      uses: dtolnay/rust-toolchain@1.91.0
     - name: Check library with MSRV
-      run: cargo check -p neo3 --lib --locked --all-features
+      run: cargo +${{ steps.msrv.outputs.name }} check -p neo3 --lib --locked --all-features
 
   lint:
     name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,24 +182,25 @@ jobs:
           ref: ${{ needs.prepare.outputs.commit }}
           persist-credentials: false
 
-      - name: Setup Rust 1.91
-        uses: dtolnay/rust-toolchain@1.91
+      - name: Setup Rust 1.96.0
+        id: rust
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: rustfmt, clippy
 
       - name: Check formatting
-        run: cargo fmt --all -- --check
+        run: cargo +${{ steps.rust.outputs.name }} fmt --all -- --check
 
       - name: Run Clippy
-        run: cargo clippy --workspace --locked --all-features --all-targets -- -D warnings
+        run: cargo +${{ steps.rust.outputs.name }} clippy --workspace --locked --all-features --all-targets -- -D warnings
 
       - name: Run workspace tests
-        run: cargo test --workspace --locked
+        run: cargo +${{ steps.rust.outputs.name }} test --workspace --locked
 
       - name: Build API documentation
         env:
           RUSTDOCFLAGS: -D warnings
-        run: cargo doc -p neo3 --locked --all-features --no-deps
+        run: cargo +${{ steps.rust.outputs.name }} doc -p neo3 --locked --all-features --no-deps
 
       - name: Audit dependencies
         uses: rustsec/audit-check@v2.0.0


### PR DESCRIPTION
## Summary

The v2.1.0 retry installed Rust 1.91.1, but rust-toolchain.toml overrode the action default and bare Cargo commands ran on newly released Rust 1.97.0. Full-workspace Clippy then failed on a lint that was not present in the toolchain used to validate the immutable release candidate.

- Pin the true MSRV check to Rust 1.91.0 and invoke Cargo through the toolchain action's resolved name.
- Pin release formatting, full-workspace Clippy, tests, and rustdoc to Rust 1.96.0 and select that toolchain explicitly.
- Preserve all strict release flags and leave the public v2.1.0 tag and tagged source unchanged.

Failed release run: https://github.com/r3e-network/neo-rust-sdk/actions/runs/29126814870

## Test Coverage

This is a workflow-only correction with no new SDK code paths. A structural regression assertion was run red before the fix and green afterward to verify both jobs select their installed toolchains.

## Pre-Landing Review

Two independent reviews plus the formal code-review gate found no blocking or informational findings.

## Verification

- [x] actionlint for both changed workflows
- [x] git diff whitespace validation
- [x] Rust 1.91.0 all-feature library check
- [x] Rust 1.96.0 formatting
- [x] Rust 1.96.0 strict full-workspace Clippy
- [x] Rust 1.96.0 workspace tests and doctests
- [x] Rust 1.96.0 API docs with warnings denied
- [x] cargo audit (configured warnings only)
- [x] cargo-deny policy
- [x] neo3 publish dry-run (279 files, 3.3 MiB)
- [x] Remote v2.1.0 tag object and commit remain unchanged

## Release Safety

The crate and GitHub release endpoints both still return 404, so publication has not started. The workflow will be retried only after this exact commit passes CI on master.
